### PR TITLE
Copy UART example to src

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,38 @@
+# Makefile - m3_uart_echo
+CROSS_COMPILE ?= arm-none-eabi-
+CC = $(CROSS_COMPILE)gcc
+OBJCOPY = $(CROSS_COMPILE)objcopy
+SIZE = $(CROSS_COMPILE)size
+
+CFLAGS = -mthumb -mcpu=cortex-m3 -O2 -Wall -g
+LDFLAGS = -T m3.ld -Wl,-Map=firmware.map,--cref,--gc-sections --specs=nano.specs --specs=nosys.specs
+
+SRC = main.c startup.c
+OBJ = $(SRC:.c=.o)
+
+# FPGA Tools
+YOSYS = yosys
+NEXTPNR = nextpnr-himbaechel
+GOWIN_PACK = gowin_pack
+
+all: firmware.bin bitstream.fs
+
+firmware.elf: $(OBJ)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJ)
+	$(SIZE) $@
+
+firmware.bin: firmware.elf
+	$(OBJCOPY) -O binary $< $@
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+bitstream.fs: top.v top.cst
+	$(YOSYS) -p "synth_gowin -top top -json top.json" top.v
+	$(NEXTPNR) --device GW1NSR-LV4CQN48PC7/I6 --family GW1NS-4 --json top.json --write top_pnr.json --vopt family=GW1NS-4 --vopt device=GW1NSR-4C --cst top.cst
+	$(GOWIN_PACK) -d GW1NS-4 top_pnr.json $@
+
+clean:
+	rm -f *.o *.elf *.bin *.map *.json *.fs
+
+.PHONY: all clean

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,42 @@
+# UART Echo Example
+
+This example demonstrates how to use the UART0 peripheral on the Cortex-M3 "Hard Core" to communicate with a host computer. It receives characters from the host, swaps their case (upper to lower and vice versa), and echoes them back, while toggling the onboard LED for every character processed.
+
+## 1. Features
+
+- **UART0 Configuration**: 115200 baud, 8-bit data, 1 stop bit, no parity.
+- **Case Conversion**: Automatically swaps uppercase 'A-Z' to lowercase 'a-z' and vice versa.
+- **LED Feedback**: The onboard LED (Pin 10) toggles with each character received.
+- **Hardware Integration**: Uses the `Gowin_EMPU_M3` hard core with UART0 routed to physical pins via the FPGA fabric.
+
+## 2. Hardware Mapping
+
+| Interface | Pin | FPGA Port |
+| :--- | :--- | :--- |
+| UART0 TX | 18 | `uart_tx` |
+| UART0 RX | 19 | `uart_rx` |
+| LED | 10 | `led_pin` |
+| Clock | 45 | `clk_27m` |
+
+## 3. Register Layout
+
+The following registers are used for UART0 (Base `0x40004000`):
+
+| Register | Offset | Description |
+| :--- | :--- | :--- |
+| `DATA` | `0x00` | Transmit/Receive data. |
+| `STATE` | `0x04` | Status bits (Bit 1: RX full, Bit 0: TX full). |
+| `CTRL` | `0x08` | Control bits (Bit 1: RX enable, Bit 0: TX enable). |
+| `BAUDDIV` | `0x10` | Baud rate divider. |
+
+## 4. Build Instructions
+
+To build the example, run `make` in this directory:
+
+```bash
+make
+```
+
+This will produce:
+- `firmware.bin`: The Cortex-M3 binary.
+- `bitstream.fs`: The FPGA bitstream.

--- a/src/m3.ld
+++ b/src/m3.ld
@@ -1,0 +1,70 @@
+/* m3.ld */
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+    INT_FLASH (rx)  : ORIGIN = 0x00000000, LENGTH = 32K
+    SRAM      (rwx) : ORIGIN = 0x20000000, LENGTH = 22K
+    PSRAM     (rwx) : ORIGIN = 0xA0000000, LENGTH = 8M
+}
+
+STACK_SIZE = 2K;
+
+SECTIONS
+{
+    /* .isr_vector always at 0x00000000 */
+    .isr_vector :
+    {
+        . = ALIGN(256);
+        KEEP(*(.isr_vector))
+        *(.boot*)
+    } > INT_FLASH
+
+    /* .text section */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text*)
+        *(.rodata*)
+        _etext = .;
+    } > INT_FLASH
+
+    /* Secure Gateway stubs */
+    .gnu.sgstubs : ALIGN(1024)
+    {
+        *(.gnu.sgstubs*)
+    } > INT_FLASH
+
+    .data : AT (_etext)
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } > SRAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+    } > SRAM
+
+    /* Extended PSRAM section */
+    .psram (NOLOAD) :
+    {
+        . = ALIGN(4);
+        *(.psram*)
+    } > PSRAM
+
+    .stack (NOLOAD) :
+    {
+        . = ALIGN(8);
+        . = . + STACK_SIZE;
+        _estack = .;
+    } > SRAM
+}

--- a/src/m3_regs.h
+++ b/src/m3_regs.h
@@ -1,0 +1,28 @@
+#ifndef M3_REGS_H
+#define M3_REGS_H
+
+#include <stdint.h>
+
+// --- UART0 ---
+#define UART0_BASE          (0x40004000)
+#define REG_UART0_DATA      (*(volatile uint32_t *)(UART0_BASE + 0x00))
+#define REG_UART0_STATE     (*(volatile uint32_t *)(UART0_BASE + 0x04))
+#define REG_UART0_CTRL      (*(volatile uint32_t *)(UART0_BASE + 0x08))
+#define REG_UART0_BAUDDIV   (*(volatile uint32_t *)(UART0_BASE + 0x10))
+
+// --- GPIO (CMSDK) ---
+#define GPIO_BASE           (0x40010000)
+#define REG_GPIO_DATA       (*(volatile uint32_t *)(GPIO_BASE + 0x00))
+#define REG_GPIO_DATAOUT    (*(volatile uint32_t *)(GPIO_BASE + 0x04))
+#define REG_GPIO_OUTENSET   (*(volatile uint32_t *)(GPIO_BASE + 0x10))
+#define REG_GPIO_OUTENCLR   (*(volatile uint32_t *)(GPIO_BASE + 0x14))
+
+// --- NVIC ---
+#define NVIC_ISER0          (*(volatile uint32_t *)(0xE000E100))
+#define NVIC_ICER0          (*(volatile uint32_t *)(0xE000E180))
+
+// --- Memory Regions ---
+#define SRAM_BASE           (0x20000000)
+#define SRAM_SIZE           (22 * 1024)
+
+#endif // M3_REGS_H

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,41 @@
+/* main.c - m3_uart_echo */
+#include "m3_regs.h"
+
+int main(void) {
+    // Configure UART0: 115200 baud @ 27MHz
+    // Divider = 27,000,000 / 115,200 = 234.375 -> 234
+    REG_UART0_BAUDDIV = 234;
+
+    // Enable UART0 TX and RX
+    // CTRL[0] = TX Enable, CTRL[1] = RX Enable
+    REG_UART0_CTRL = (1 << 1) | (1 << 0);
+
+    // Configure GPIO0 (LED) as output
+    REG_GPIO_OUTENSET = (1 << 0);
+
+    while (1) {
+        // Poll for RX buffer full (STATE[1])
+        if (REG_UART0_STATE & (1 << 1)) {
+            // Read received character
+            uint8_t c = (uint8_t)REG_UART0_DATA;
+
+            // Toggle LED
+            REG_GPIO_DATAOUT ^= (1 << 0);
+
+            // Case conversion
+            if (c >= 'a' && c <= 'z') {
+                c = c - ('a' - 'A');
+            } else if (c >= 'A' && c <= 'Z') {
+                c = c + ('a' - 'A');
+            }
+
+            // Wait for TX buffer not full (STATE[0] == 0)
+            while (REG_UART0_STATE & (1 << 0));
+
+            // Echo character back
+            REG_UART0_DATA = c;
+        }
+    }
+
+    return 0;
+}

--- a/src/startup.c
+++ b/src/startup.c
@@ -1,0 +1,52 @@
+/* startup.c */
+#include <stdint.h>
+
+extern uint32_t _estack;
+extern uint32_t _etext;
+extern uint32_t _sdata;
+extern uint32_t _edata;
+extern uint32_t _sbss;
+extern uint32_t _ebss;
+
+void main(void);
+
+void Reset_Handler(void) __attribute__((naked, section(".boot")));
+void Reset_Handler(void) {
+    // Set stack pointer
+    __asm volatile ("ldr sp, =_estack");
+
+    // Copy .data section from flash to RAM
+    for (uint32_t *src = &_etext, *dest = &_sdata; dest < &_edata;) {
+        *dest++ = *src++;
+    }
+
+    // Zero out .bss section
+    for (uint32_t *dest = &_sbss; dest < &_ebss;) {
+        *dest++ = 0;
+    }
+
+    // Jump to main
+    main();
+    for (;;);
+}
+
+void Default_Handler(void) {
+    while (1);
+}
+
+// Minimal ISR Vector Table
+const uint32_t isr_vector[] __attribute__((section(".isr_vector"), aligned(256))) = {
+    (uint32_t)&_estack,
+    (uint32_t)&Reset_Handler,
+    (uint32_t)&Default_Handler, // NMI
+    (uint32_t)&Default_Handler, // HardFault
+    (uint32_t)&Default_Handler, // MemManage
+    (uint32_t)&Default_Handler, // BusFault
+    (uint32_t)&Default_Handler, // UsageFault
+    0, 0, 0, 0,                 // Reserved
+    (uint32_t)&Default_Handler, // SVCall
+    (uint32_t)&Default_Handler, // DebugMonitor
+    0,                          // Reserved
+    (uint32_t)&Default_Handler, // PendSV
+    (uint32_t)&Default_Handler, // SysTick
+};

--- a/src/top.cst
+++ b/src/top.cst
@@ -1,0 +1,12 @@
+// top.cst - m3_uart_echo
+IO_LOC "clk_27m" 45;
+IO_PORT "clk_27m" IO_TYPE=LVCMOS33;
+
+IO_LOC "uart_tx" 18;
+IO_PORT "uart_tx" IO_TYPE=LVCMOS33;
+
+IO_LOC "uart_rx" 19;
+IO_PORT "uart_rx" IO_TYPE=LVCMOS33;
+
+IO_LOC "led_pin" 10;
+IO_PORT "led_pin" IO_TYPE=LVCMOS33;

--- a/src/top.v
+++ b/src/top.v
@@ -1,0 +1,25 @@
+/* top.v - m3_uart_echo */
+`default_nettype none
+
+module top (
+    input  wire clk_27m,      // Pin 45
+    output wire uart_tx,      // Pin 18
+    input  wire uart_rx,      // Pin 19
+    output wire led_pin       // Pin 10
+);
+
+    // GPIO
+    wire [15:0] m3_gpio_o;
+    assign led_pin = m3_gpio_o[0];
+
+    // --- M3 IP Core Instantiation ---
+    Gowin_EMPU_M3 m3_inst (
+        .SYS_CLK     (clk_27m),
+        .UART0RXD    (uart_rx),
+        .UART0TXD    (uart_tx),
+
+        // GPIO
+        .GPIOO       (m3_gpio_o)
+    );
+
+endmodule


### PR DESCRIPTION
I have copied the `m3_uart_echo` example from the `chatelao/micropython-tang-nano` repository into the `src` directory.

The copied files include:
- `Makefile`
- `README.md`
- `m3.ld`
- `m3_regs.h`
- `main.c`
- `startup.c`
- `top.cst`
- `top.v`

I verified the files by listing the directory contents and performing a dry run of the `Makefile` using `make -n`. Although the `arm-none-eabi-gcc` toolchain is not present in the current environment to perform a full build, the dry run confirmed that the `Makefile` and all dependencies are correctly structured for the intended build process.

Fixes #1

---
*PR created automatically by Jules for task [8696037464999155264](https://jules.google.com/task/8696037464999155264) started by @chatelao*