### PR TITLE
Create Tiny Tapeout Web Tester and GH Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy Web Page
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './web'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const uiIn = document.getElementById('ui_in').querySelectorAll('input');
+    const uioIn = document.getElementById('uio_in').querySelectorAll('input');
+    const clk = document.getElementById('clk');
+    const rstN = document.getElementById('rst_n');
+    const ena = document.getElementById('ena');
+    const uoOut = document.getElementById('uo_out').querySelectorAll('.bit');
+    const uioOut = document.getElementById('uio_out').querySelectorAll('.bit');
+    const uioOe = document.getElementById('uio_oe').querySelectorAll('.bit');
+    const sendReceiveBtn = document.getElementById('sendReceive');
+    const consoleDiv = document.getElementById('console');
+
+    function logToConsole(message) {
+        const timestamp = new Date().toLocaleTimeString();
+        consoleDiv.textContent += `[${timestamp}] ${message}\n`;
+        consoleDiv.scrollTop = consoleDiv.scrollHeight;
+    }
+
+    function getBits(inputs) {
+        let val = 0;
+        inputs.forEach((input, index) => {
+            if (input.checked) {
+                val |= (1 << (7 - index));
+            }
+        });
+        return val;
+    }
+
+    function setBits(elements, value) {
+        elements.forEach((el, index) => {
+            const bit = (value >> (7 - index)) & 1;
+            el.textContent = bit;
+            if (bit) {
+                el.classList.add('high');
+            } else {
+                el.classList.remove('high');
+            }
+        });
+    }
+
+    sendReceiveBtn.addEventListener('click', () => {
+        const uiValue = getBits(uiIn);
+        const uioInValue = getBits(uioIn);
+        const clkVal = clk.checked ? 1 : 0;
+        const rstVal = rstN.checked ? 1 : 0;
+        const enaVal = ena.checked ? 1 : 0;
+
+        logToConsole(`Sending: ui_in=0x${uiValue.toString(16).padStart(2, '0')}, uio_in=0x${uioInValue.toString(16).padStart(2, '0')}, clk=${clkVal}, rst_n=${rstVal}, ena=${enaVal}`);
+
+        // Emulate behavior: Summing ui_in and uio_in as seen in the template
+        const result = (uiValue + uioInValue) & 0xFF;
+
+        // Update mock outputs
+        setBits(uoOut, result);
+        setBits(uioOut, 0);
+        setBits(uioOe, 0);
+
+        logToConsole(`Received (Emulated): uo_out=0x${result.toString(16).padStart(2, '0')}`);
+    });
+
+    logToConsole('Tiny Tapeout Web Tester Initialized');
+    logToConsole('Note: WebSerial functionality is TBD');
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tiny Tapeout Web Tester</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Tiny Tapeout Web Tester</h1>
+
+        <div class="grid">
+            <div class="panel">
+                <h2>Inputs</h2>
+                <div class="signal-group">
+                    <label>ui_in [7:0]</label>
+                    <div class="bits" id="ui_in">
+                        <input type="checkbox" title="bit 7">
+                        <input type="checkbox" title="bit 6">
+                        <input type="checkbox" title="bit 5">
+                        <input type="checkbox" title="bit 4">
+                        <input type="checkbox" title="bit 3">
+                        <input type="checkbox" title="bit 2">
+                        <input type="checkbox" title="bit 1">
+                        <input type="checkbox" title="bit 0">
+                    </div>
+                </div>
+                <div class="signal-group">
+                    <label>uio_in [7:0]</label>
+                    <div class="bits" id="uio_in">
+                        <input type="checkbox" title="bit 7">
+                        <input type="checkbox" title="bit 6">
+                        <input type="checkbox" title="bit 5">
+                        <input type="checkbox" title="bit 4">
+                        <input type="checkbox" title="bit 3">
+                        <input type="checkbox" title="bit 2">
+                        <input type="checkbox" title="bit 1">
+                        <input type="checkbox" title="bit 0">
+                    </div>
+                </div>
+                <div class="signal-group-inline">
+                    <label><input type="checkbox" id="clk"> clk</label>
+                    <label><input type="checkbox" id="rst_n" checked> rst_n</label>
+                    <label><input type="checkbox" id="ena" checked> ena</label>
+                </div>
+
+                <button id="sendReceive">Send & Receive</button>
+                <div class="tbd">WebSerial TBD</div>
+            </div>
+
+            <div class="panel">
+                <h2>Outputs</h2>
+                <div class="signal-group">
+                    <label>uo_out [7:0]</label>
+                    <div class="bits-out" id="uo_out">
+                        <span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span>
+                    </div>
+                </div>
+                <div class="signal-group">
+                    <label>uio_out [7:0]</label>
+                    <div class="bits-out" id="uio_out">
+                        <span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span>
+                    </div>
+                </div>
+                <div class="signal-group">
+                    <label>uio_oe [7:0]</label>
+                    <div class="bits-out" id="uio_oe">
+                        <span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span><span class="bit">0</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="panel console-panel">
+            <h2>Serial Console</h2>
+            <div id="console" class="console"></div>
+        </div>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,124 @@
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background-color: #f0f2f5;
+    color: #1c1e21;
+    margin: 0;
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+}
+
+.container {
+    max-width: 900px;
+    width: 100%;
+}
+
+h1 {
+    text-align: center;
+    color: #050505;
+}
+
+h2 {
+    margin-top: 0;
+    font-size: 1.2rem;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 10px;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.panel {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.signal-group {
+    margin-bottom: 15px;
+}
+
+.signal-group label {
+    display: block;
+    font-weight: bold;
+    margin-bottom: 5px;
+    font-family: monospace;
+}
+
+.bits {
+    display: flex;
+    gap: 4px;
+}
+
+.bits-out {
+    display: flex;
+    gap: 4px;
+}
+
+.bit {
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    line-height: 24px;
+    text-align: center;
+    background: #e4e6eb;
+    border-radius: 4px;
+    font-family: monospace;
+    font-weight: bold;
+}
+
+.bit.high {
+    background: #42b72a;
+    color: white;
+}
+
+.signal-group-inline {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 20px;
+    font-family: monospace;
+}
+
+button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 6px;
+    font-size: 1rem;
+    cursor: pointer;
+    width: 100%;
+    font-weight: bold;
+    transition: background-color 0.2s;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+.tbd {
+    text-align: center;
+    margin-top: 10px;
+    font-size: 0.9rem;
+    color: #65676b;
+}
+
+.console-panel {
+    margin-top: 20px;
+}
+
+.console {
+    background: #1c1e21;
+    color: #00ff00;
+    font-family: 'Courier New', Courier, monospace;
+    padding: 15px;
+    border-radius: 6px;
+    height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
I have created a web-based testing interface for Tiny Tapeout projects, located in the `/web` directory for independent usage. This interface allows users to toggle input signals (ui_in, uio_in, clk, rst_n, ena) and observe the resulting output signals (uo_out, uio_out, uio_oe). It also includes a "Send & Receive" button that triggers an emulated serial response in a dedicated console area.

Additionally, I have configured a GitHub Actions workflow to automatically deploy this web tester to GitHub Pages whenever a push is made to the `main` branch. 

Key features:
- Title: "Tiny Tapeout Web Tester"
- Bit-level input and output signal displays.
- Emulated serial communication console.
- "WebSerial TBD" placeholder.
- Automated deployment to GitHub Pages.

Fixes #4

---
*PR created automatically by Jules for task [15926217247515327513](https://jules.google.com/task/15926217247515327513) started by @chatelao*