### PR TITLE
Remove external SPI Flash and PSRAM from documentation and architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ The diagram below shows the high-level integration of the Tiny Tapeout Web Seria
 | **FPGABridge** | Low-level access to the 16-bit M3-to-FPGA GPIO bridge (See [FPGA_BRIDGE_USAGE.md](FPGA_BRIDGE_USAGE.md)) |
 | **NEORV32** | Integration example for the NEORV32 RISC-V co-processor (See `examples/cpus/neorv32/`) |
 | **SERV RISC-V** | Example of running a RISC-V core in the FPGA fabric (See `examples/cpus/serv_riscv/`) |
-| **Flash** | Block device interface for the onboard SPI Flash |
-| **Filesystem** | LittleFS (LFS2) on external SPI Flash |
 | **Runtime** | Garbage Collector, REPL over UART0 |
 
 ## Unsupported Features
@@ -54,8 +52,6 @@ The diagram below shows the high-level integration of the Tiny Tapeout Web Seria
 | **M3 Int. Boot-Flash**  |   32 KB* | `0x00000000` | `firmware_int.bin` | Vector Table & Reset Handler                 |
 | **M3 Internal SRAM**    |   22 KB  | `0x20000000` | -                  | Stack (2KB) & Fast Heap (~18KB)              |
 | **M3 APB2 Devices** |   16 B   | `0x40002400` | -                  | TT Wrapper, Slot (1/12): TT Control and Data |
-| **M3 Ext. Run-Flash**   |    4 MB  | `0x60000000` | `firmware_ext.bin` | SPI Flash Access (XIP) & VFS                 |
-| **M3 Ext. PSRAM**       |    8 MB  | `0xA0000000` | -                  | Primary Heap (External PSRAM)                |
 
 *\* Note: Internal Flash address space is 128 KB, but physical hardware on Tang Nano 4K is limited to 32 KB.*
 
@@ -151,10 +147,8 @@ Setting up the SoC subsystem on the Tang Nano 4K requires specific IP core confi
 
 | Feature / IP Core | Configuration / Notes |
 | :--- | :--- |
-| **Cortex-M3 (Gowin_EMPU_M3)** | Enable APB and AHB expansion to allow the M3 to communicate with logic and memory in the FPGA fabric |
+| **Cortex-M3 (Gowin_EMPU_M3)** | Enable APB expansion to allow the M3 to communicate with logic in the FPGA fabric |
 | **APB2 Expansion** | Each slot (256 bytes) is mapped starting at `0x40002400` |
-| **External PSRAM** | Requires the `PSRAM Memory Interface` IP (Model: W955D8MBYA) mapped to `0xA0000000` |
-| **External SPI Flash (XIP)** | Requires the `SPI Flash Interface` IP mapped to `0x60000000` |
 
 For step-by-step instructions and pin constraints, see the **[M3-FPGA Integration Guide](M3_FPGA_INTEGRATIONS.md#3-apb2-expansion-slots)**.
 
@@ -162,10 +156,9 @@ For step-by-step instructions and pin constraints, see the **[M3-FPGA Integratio
 
 | Step | Description | Details / Parameters |
 | :--- | :--- | :--- |
-| 1 | **Build** | Compile firmware with `SPLIT_FLASH=1` |
-| 2 | **Flash FPGA Bitstream** | Flash the `.fs` file containing the SPI Flash Interface IP |
+| 1 | **Build** | Compile firmware |
+| 2 | **Flash FPGA Bitstream** | Flash the `.fs` file |
 | 3 | **Flash Internal Flash** | Access Mode: `MCU Mode`<br>Operation: `Flash Erase, Program, Verify`<br>File: `build/firmware_int.bin` |
-| 4 | **Flash External Flash** | Access Mode: `External Flash Mode`<br>Operation: `exFlash Erase, Program, Verify`<br>File: `build/firmware_ext.bin`<br>Address: `0x000000` (Mapped to `0x60000000`) |
 
 For more details on M3-FPGA integration, see [M3_FPGA_INTEGRATIONS.md](M3_FPGA_INTEGRATIONS.md).
 

--- a/architecture.puml
+++ b/architecture.puml
@@ -18,12 +18,8 @@ Container_Boundary(soc, "GW1NSR-4C SoC (Tang Nano 4K)") {
 
     Boundary(fabric, "FPGA Fabric") {
         Component(apb_slots, "APB2 Slots (0x40002400)", "Register-mapped", "TT Control and Data")
-        Component(psram_ctrl, "PSRAM Controller", "AHB (0xA0000000)", "W955D8MBYA (8MB)")
-        Component(flash_ctrl, "SPI Flash Interface", "AHB (0x60000000)", "XIP (4MB)")
 
         Rel(m3, apb_slots, "APB2 Expansion")
-        Rel(m3, psram_ctrl, "AHB Expansion")
-        Rel(m3, flash_ctrl, "AHB Expansion")
     }
 
     Component(int_flash, "Internal Flash (32KB)", "0x00000000", "Bootloader & Vectors")
@@ -35,11 +31,6 @@ Container_Boundary(soc, "GW1NSR-4C SoC (Tang Nano 4K)") {
     Rel(m3, uart0, "APB")
 }
 
-Component_Ext(ext_psram, "External PSRAM", "Physical Chip", "8MB 166MHz")
-Component_Ext(ext_flash, "External SPI Flash", "Physical Chip", "4MB Tiny Tapeout Web Serial VFS")
-
-Rel(psram_ctrl, ext_psram, "DQ[15:0], SCLK, CS#")
-Rel(flash_ctrl, ext_flash, "MOSI, MISO, SCLK, CS#")
 Rel(user, browser, "Interacts with")
 Rel(browser, uart0, "WebSerial", "USB-C Bridge (Pins 18/19)")
 


### PR DESCRIPTION
This change removes documentation and architectural diagram references to external SPI Flash and PSRAM memory components from the Tang Nano 4K Tiny Tapeout Web Serial project. The updates ensure the documentation accurately reflects the hardware's supported configuration by removing unsupported or simplified memory features and their associated build/flash steps.

Fixes #18

---
*PR created automatically by Jules for task [11491645262061714889](https://jules.google.com/task/11491645262061714889) started by @chatelao*