### PR TITLE
Change clock field to dropdown with '1/0' support

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -87,13 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
         historyBody.prepend(row);
     }
 
-    sendReceiveBtn.addEventListener('click', () => {
-        const uiValue = getBits(uiIn);
-        const uioInValue = getBits(uioIn);
-        const clkVal = clk.checked ? 1 : 0;
-        const rstVal = rstN.checked ? 1 : 0;
-        const enaVal = ena.checked ? 1 : 0;
-
+    function performTransaction(uiValue, uioInValue, clkVal, rstVal, enaVal) {
         const inputs = {
             ui_in: uiValue,
             uio_in: uioInValue,
@@ -114,8 +108,23 @@ document.addEventListener('DOMContentLoaded', () => {
         };
 
         addHistoryRow(inputs, outputs);
-
         logToConsole(`Received (Emulated): uo_out=0x${result.toString(16).padStart(2, '0')}`);
+    }
+
+    sendReceiveBtn.addEventListener('click', () => {
+        const uiValue = getBits(uiIn);
+        const uioInValue = getBits(uioIn);
+        const rstVal = rstN.checked ? 1 : 0;
+        const enaVal = ena.checked ? 1 : 0;
+        const clkSelection = clk.value;
+
+        if (clkSelection === '1/0') {
+            performTransaction(uiValue, uioInValue, 1, rstVal, enaVal);
+            performTransaction(uiValue, uioInValue, 0, rstVal, enaVal);
+        } else {
+            const clkVal = parseInt(clkSelection);
+            performTransaction(uiValue, uioInValue, clkVal, rstVal, enaVal);
+        }
     });
 
     logToConsole('Tiny Tapeout Web Tester Initialized');

--- a/web/index.html
+++ b/web/index.html
@@ -39,7 +39,13 @@
                                 <input type="checkbox" title="7"><input type="checkbox" title="6"><input type="checkbox" title="5"><input type="checkbox" title="4"><input type="checkbox" title="3"><input type="checkbox" title="2"><input type="checkbox" title="1"><input type="checkbox" title="0">
                             </div>
                         </td>
-                        <td class="center-cell"><input type="checkbox" id="clk"></td>
+                        <td class="center-cell">
+                            <select id="clk">
+                                <option value="0">0</option>
+                                <option value="1">1</option>
+                                <option value="1/0">1/0</option>
+                            </select>
+                        </td>
                         <td class="center-cell"><input type="checkbox" id="rst_n" checked></td>
                         <td class="center-cell"><input type="checkbox" id="ena" checked></td>
                         <td colspan="3" class="results-placeholder">Ready to send...</td>

--- a/web/style.css
+++ b/web/style.css
@@ -94,6 +94,12 @@ h1 {
     height: 18px;
 }
 
+.center-cell select {
+    padding: 2px;
+    font-family: monospace;
+    font-size: 0.9rem;
+}
+
 button {
     background-color: #007bff;
     color: white;


### PR DESCRIPTION
This change replaces the clock (clk) checkbox with a dropdown menu in the Tiny Tapeout Web Tester. The dropdown includes options for '0', '1', and a special '1/0' mode. When '1/0' is selected and the 'Send' button is clicked, the tester automatically executes two consecutive transactions: first with clk=1 and then with clk=0. This simulates a full clock cycle while ensuring all other input signals (ui_in, uio_in, rst_n, ena) remain constant across both steps. The transaction history correctly displays both steps as separate entries. Styling was also updated to ensure the dropdown fits cleanly within the interface.

Fixes #21

---
*PR created automatically by Jules for task [13670394061803751409](https://jules.google.com/task/13670394061803751409) started by @chatelao*