### PR TITLE
Add synchronized hex entry fields to bit patterns

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1,6 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
     const uiIn = document.getElementById('ui_in').querySelectorAll('input');
     const uioIn = document.getElementById('uio_in').querySelectorAll('input');
+    const uiInHex = document.getElementById('ui_in_hex');
+    const uioInHex = document.getElementById('uio_in_hex');
     const clk = document.getElementById('clk');
     const rstN = document.getElementById('rst_n');
     const ena = document.getElementById('ena');
@@ -24,6 +26,31 @@ document.addEventListener('DOMContentLoaded', () => {
         return val;
     }
 
+    function updateHexFromBits(inputs, hexInput) {
+        const val = getBits(inputs);
+        hexInput.value = val.toString(16).padStart(2, '0').toUpperCase();
+    }
+
+    function updateBitsFromHex(hexInput, inputs) {
+        let val = parseInt(hexInput.value, 16);
+        if (isNaN(val)) val = 0;
+        val &= 0xFF;
+        inputs.forEach((input, index) => {
+            input.checked = (val >> (7 - index)) & 1;
+        });
+    }
+
+    uiIn.forEach(input => {
+        input.addEventListener('change', () => updateHexFromBits(uiIn, uiInHex));
+    });
+
+    uioIn.forEach(input => {
+        input.addEventListener('change', () => updateHexFromBits(uioIn, uioInHex));
+    });
+
+    uiInHex.addEventListener('input', () => updateBitsFromHex(uiInHex, uiIn));
+    uioInHex.addEventListener('input', () => updateBitsFromHex(uioInHex, uioIn));
+
     function createBitDisplay(value) {
         const container = document.createElement('div');
         container.className = 'bits-out';
@@ -34,6 +61,10 @@ document.addEventListener('DOMContentLoaded', () => {
             span.textContent = bitVal;
             container.appendChild(span);
         }
+        const hexSpan = document.createElement('span');
+        hexSpan.className = 'hex-display';
+        hexSpan.textContent = `0x${value.toString(16).padStart(2, '0').toUpperCase()}`;
+        container.appendChild(hexSpan);
         return container;
     }
 

--- a/web/index.html
+++ b/web/index.html
@@ -30,13 +30,19 @@
                     <tr class="input-row">
                         <td class="time-cell">-</td>
                         <td>
-                            <div class="bits" id="ui_in">
-                                <input type="checkbox" title="7"><input type="checkbox" title="6"><input type="checkbox" title="5"><input type="checkbox" title="4"><input type="checkbox" title="3"><input type="checkbox" title="2"><input type="checkbox" title="1"><input type="checkbox" title="0">
+                            <div class="bits-container">
+                                <div class="bits" id="ui_in">
+                                    <input type="checkbox" title="7"><input type="checkbox" title="6"><input type="checkbox" title="5"><input type="checkbox" title="4"><input type="checkbox" title="3"><input type="checkbox" title="2"><input type="checkbox" title="1"><input type="checkbox" title="0">
+                                </div>
+                                <input type="text" class="hex-input" id="ui_in_hex" maxlength="2" value="00">
                             </div>
                         </td>
                         <td>
-                            <div class="bits" id="uio_in">
-                                <input type="checkbox" title="7"><input type="checkbox" title="6"><input type="checkbox" title="5"><input type="checkbox" title="4"><input type="checkbox" title="3"><input type="checkbox" title="2"><input type="checkbox" title="1"><input type="checkbox" title="0">
+                            <div class="bits-container">
+                                <div class="bits" id="uio_in">
+                                    <input type="checkbox" title="7"><input type="checkbox" title="6"><input type="checkbox" title="5"><input type="checkbox" title="4"><input type="checkbox" title="3"><input type="checkbox" title="2"><input type="checkbox" title="1"><input type="checkbox" title="0">
+                                </div>
+                                <input type="text" class="hex-input" id="uio_in_hex" maxlength="2" value="00">
                             </div>
                         </td>
                         <td class="center-cell"><input type="checkbox" id="clk"></td>

--- a/web/style.css
+++ b/web/style.css
@@ -61,6 +61,29 @@ h1 {
     justify-content: center;
 }
 
+.bits-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    justify-content: center;
+}
+
+.hex-input {
+    width: 35px;
+    font-family: monospace;
+    text-align: center;
+    padding: 2px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+.hex-display {
+    margin-left: 8px;
+    font-family: monospace;
+    color: #65676b;
+    font-size: 0.85rem;
+}
+
 .bits input[type="checkbox"] {
     margin: 0;
     width: 16px;


### PR DESCRIPTION
This PR adds hexadecimal entry fields next to the bitwise checkbox patterns for the `ui_in` and `uio_in` signals in the Tiny Tapeout Web Tester. It also ensures that the bit fields and hex inputs remain synchronized: toggling a checkbox updates the hex value, and editing the hex value updates the checkboxes. Additionally, a hexadecimal representation (e.g., `0xXX`) is now displayed next to bit patterns in the history and output rows for better readability.

Key changes:
- `web/index.html`: Added hex input fields (`ui_in_hex`, `uio_in_hex`) and wrapped bit displays in containers.
- `web/style.css`: Added styles for the new `.bits-container`, `.hex-input`, and `.hex-display` classes.
- `web/app.js`: Implemented `updateHexFromBits` and `updateBitsFromHex` logic with corresponding event listeners for real-time synchronization. Updated `createBitDisplay` to append a hex label to bit patterns.

Verified the changes with a Playwright script and visual inspection of screenshots.

Fixes #20

---
*PR created automatically by Jules for task [14162502694799241054](https://jules.google.com/task/14162502694799241054) started by @chatelao*