### PR TITLE
Add '0x' prefix and reset button to hex inputs

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -3,6 +3,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const uioIn = document.getElementById('uio_in').querySelectorAll('input');
     const uiInHex = document.getElementById('ui_in_hex');
     const uioInHex = document.getElementById('uio_in_hex');
+    const uiInReset = document.getElementById('ui_in_reset');
+    const uioInReset = document.getElementById('uio_in_reset');
     const clk = document.getElementById('clk');
     const rstN = document.getElementById('rst_n');
     const ena = document.getElementById('ena');
@@ -50,6 +52,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     uiInHex.addEventListener('input', () => updateBitsFromHex(uiInHex, uiIn));
     uioInHex.addEventListener('input', () => updateBitsFromHex(uioInHex, uioIn));
+
+    uiInReset.addEventListener('click', () => {
+        uiInHex.value = '00';
+        updateBitsFromHex(uiInHex, uiIn);
+    });
+
+    uioInReset.addEventListener('click', () => {
+        uioInHex.value = '00';
+        updateBitsFromHex(uioInHex, uioIn);
+    });
 
     function createBitDisplay(value) {
         const container = document.createElement('div');

--- a/web/index.html
+++ b/web/index.html
@@ -34,7 +34,11 @@
                                 <div class="bits" id="ui_in">
                                     <input type="checkbox" title="7"><input type="checkbox" title="6"><input type="checkbox" title="5"><input type="checkbox" title="4"><input type="checkbox" title="3"><input type="checkbox" title="2"><input type="checkbox" title="1"><input type="checkbox" title="0">
                                 </div>
-                                <input type="text" class="hex-input" id="ui_in_hex" maxlength="2" value="00">
+                                <div class="hex-entry">
+                                    <span class="hex-prefix">0x</span>
+                                    <input type="text" class="hex-input" id="ui_in_hex" maxlength="2" value="00">
+                                    <button class="hex-reset" id="ui_in_reset" title="Reset to 0x00">&times;</button>
+                                </div>
                             </div>
                         </td>
                         <td>
@@ -42,7 +46,11 @@
                                 <div class="bits" id="uio_in">
                                     <input type="checkbox" title="7"><input type="checkbox" title="6"><input type="checkbox" title="5"><input type="checkbox" title="4"><input type="checkbox" title="3"><input type="checkbox" title="2"><input type="checkbox" title="1"><input type="checkbox" title="0">
                                 </div>
-                                <input type="text" class="hex-input" id="uio_in_hex" maxlength="2" value="00">
+                                <div class="hex-entry">
+                                    <span class="hex-prefix">0x</span>
+                                    <input type="text" class="hex-input" id="uio_in_hex" maxlength="2" value="00">
+                                    <button class="hex-reset" id="uio_in_reset" title="Reset to 0x00">&times;</button>
+                                </div>
                             </div>
                         </td>
                         <td class="center-cell">

--- a/web/style.css
+++ b/web/style.css
@@ -68,13 +68,46 @@ h1 {
     justify-content: center;
 }
 
+.hex-entry {
+    display: flex;
+    align-items: center;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: #fff;
+    padding-left: 4px;
+}
+
+.hex-prefix {
+    font-family: monospace;
+    color: #65676b;
+    font-size: 0.9rem;
+}
+
 .hex-input {
-    width: 35px;
+    width: 25px;
     font-family: monospace;
     text-align: center;
     padding: 2px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+    border: none;
+    outline: none;
+}
+
+.hex-reset {
+    color: #dc3545;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0 4px;
+    font-size: 1.2rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.hex-reset:hover {
+    color: #a71d2a;
+    background: none;
 }
 
 .hex-display {


### PR DESCRIPTION
This PR enhances the Tiny Tapeout Web Tester's hex input fields by adding a fixed "0x" prefix and a red cross reset button. Clicking the reset button clears the hex value to "00" and automatically synchronizes the bit checkboxes.

Key changes:
- **HTML**: Introduced `.hex-entry` containers for `ui_in_hex` and `uio_in_hex`. Added `<span class="hex-prefix">0x</span>` and `<button class="hex-reset">` elements.
- **CSS**: Styled the new components for a unified look. The hex input's border was moved to the parent container. The reset button is styled as a red cross (`&times;`) that appears on the right.
- **JS**: Added event listeners to the new reset buttons. They set the input value to "00" and call `updateBitsFromHex` to ensure the bit checkboxes are updated immediately.

Visual verification was performed using Playwright, confirming that the prefix is visible and the reset functionality works as expected.

Fixes #26

---
*PR created automatically by Jules for task [18059024932108268787](https://jules.google.com/task/18059024932108268787) started by @chatelao*