### PR TITLE
Add Web Serial API Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ The diagram below shows the high-level integration of the Tiny Tapeout Web Seria
 
 ## Supported Tiny Tapeout Web Serial Features
 
-<tbd later>
+For detailed information on the Web Serial API features utilized in this project, please refer to the **[Web Serial API Documentation](SERIAL_PORT_ACCESS.md)**.
+
+### Key Capabilities:
+- **Port Detection & Filtering**: Target specific hardware via USB `vendorId` and `productId`.
+- **Interface Configuration**: Support for custom baud rates, data bits, stop bits, and parity.
+- **Asynchronous I/O**: High-performance streaming with native backpressure management.
+- **Hardware Flow Control**: Direct manipulation and monitoring of physical control lines (DTR, RTS, etc.).
+- **Hot-Plugging**: Real-time detection of device connection and disconnection.
 
 ## Memory Layout
 
@@ -46,7 +53,7 @@ The diagram below shows the high-level integration of the Tiny Tapeout Web Seria
 | `HOWTO_TINY_TAPEOUT.md` | Guide to loading and testing Tiny Tapeout modules | Planned |
 | `README.md` | Overview of the product | Present |
 | `ROADMAP.md` | Progress tracking and future steps | Planned |
-| `SERIAL_PORT_ACCESS.md` | Guide to accessing the Cortex-M3 serial port | Planned |
+| `SERIAL_PORT_ACCESS.md` | Guide to accessing the Cortex-M3 serial port | Present |
 | `TOOLCHAIN_SETUP.md` | Instructions for setting up the toolchains | Planned |
 
 ## UART Configuration

--- a/SERIAL_PORT_ACCESS.md
+++ b/SERIAL_PORT_ACCESS.md
@@ -1,0 +1,13 @@
+# Web Serial API Documentation
+
+This document provides an overview of the Web Serial API features supported and used by the Tiny Tapeout Web Serial interface.
+
+## Web Serial API Feature Spectrum
+
+| Feature | Description | Technical Specifications & Details | Verified Source |
+| :--- | :--- | :--- | :--- |
+| **Port Detection & Filtering** | Searching and requesting devices. | `navigator.serial.requestPort()` allows targeted filtering by USB `vendorId` and `productId` to show only compatible hardware in the selection dialog. | [W3C Draft: requestPort](https://wicg.github.io/serial/#dom-navigator-requestport) |
+| **Interface Configuration** | Parameterization of the serial connection. | `port.open(options)` supports settings for `baudRate` (up to proprietary rates >1Mbit/s), `dataBits` (7 or 8), `stopBits` (1 or 2), `parity` (none, even, odd), and `bufferSize`. | [W3C Draft: SerialOptions](https://wicg.github.io/serial/#dom-serialoptions) |
+| **Asynchronous I/O Streaming** | Reading and writing payload data. | Uses the standard Streams API (`ReadableStream`, `WritableStream`). Data circulates as `Uint8Array`. Allows native backpressure management in the browser. | [W3C Draft: Streams](https://wicg.github.io/serial/#dom-serial-readable) |
+| **Hardware Flow Control** | Manipulation of physical control lines. | `setSignals()` manipulates DTR, RTS, and Break signals. `getSignals()` reads the status of CTS, DSR, DCD, and RI (Ring Indicator). | [W3C Draft: Signals](https://wicg.github.io/serial/#dom-serialport-setsignals) |
+| **Hot-Plugging Events** | Monitoring the physical status. | The `connect` and `disconnect` events on the `navigator.serial` object report in real-time when an authorized device is physically plugged in or unplugged. | [MDN: Serial Events](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/serial_event) |


### PR DESCRIPTION
This PR adds documentation for the Web Serial API features used in the Tiny Tapeout Web Serial project. It translates the technical specifications provided in the issue from German to English and integrates them into the project's documentation structure.

Key changes:
- New file `SERIAL_PORT_ACCESS.md` containing a detailed spectrum of Web Serial API features (Port Filtering, Configuration, Asynchronous I/O, Hardware Flow Control, and Hot-Plugging).
- Updated `README.md` with a summary of these capabilities and a link to the full documentation.
- Updated the "Project Structure" table in `README.md` to reflect that `SERIAL_PORT_ACCESS.md` is now present.
- Verified that `GEMINI.md` already includes the file in its project structure list.

Fixes #39

---
*PR created automatically by Jules for task [6963989835400845158](https://jules.google.com/task/6963989835400845158) started by @chatelao*