### PR TITLE
Relocate Export button and add Reset functionality

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const ena = document.getElementById('ena');
     const sendReceiveBtn = document.getElementById('sendReceive');
     const exportCsvBtn = document.getElementById('exportCsv');
+    const clearDataBtn = document.getElementById('clearData');
     const historyBody = document.getElementById('history');
     const consoleDiv = document.getElementById('console');
     const historyData = [];
@@ -220,6 +221,13 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     exportCsvBtn.addEventListener('click', exportToCsv);
+
+    clearDataBtn.addEventListener('click', () => {
+        historyData.length = 0;
+        historyBody.innerHTML = '';
+        consoleDiv.textContent = '';
+        logToConsole('History and console cleared');
+    });
 
     logToConsole('Tiny Tapeout Web Tester Initialized');
     logToConsole('Note: WebSerial functionality is TBD');

--- a/web/index.html
+++ b/web/index.html
@@ -11,6 +11,10 @@
         <h1>Tiny Tapeout Web Tester</h1>
 
         <div class="panel main-panel">
+            <div class="table-actions">
+                <button id="exportCsv">Export CSV</button>
+                <button id="clearData">Reset</button>
+            </div>
             <table class="tester-table">
                 <thead>
                     <tr>
@@ -65,7 +69,6 @@
                         <td colspan="3" class="results-placeholder">Ready to send...</td>
                         <td>
                             <button id="sendReceive">Send</button>
-                            <button id="exportCsv">Export CSV</button>
                         </td>
                     </tr>
                 </tbody>

--- a/web/style.css
+++ b/web/style.css
@@ -172,13 +172,27 @@ button:hover {
     background-color: #0056b3;
 }
 
+.table-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
 #exportCsv {
     background-color: #6c757d;
-    margin-left: 5px;
 }
 
 #exportCsv:hover {
     background-color: #5a6268;
+}
+
+#clearData {
+    background-color: #dc3545;
+}
+
+#clearData:hover {
+    background-color: #a71d2a;
 }
 
 .tbd {


### PR DESCRIPTION
This change improves the Tiny Tapeout Web Tester UI by relocating the "Export CSV" button to a more intuitive position above the history table and adding a new "Reset" button to clear all session data (history and console).

Changes:
- In `web/index.html`, added a `table-actions` div and moved the export button there, adding the new reset button.
- In `web/style.css`, added styling for the new button layout and a distinct red style for the reset button.
- In `web/app.js`, added logic to clear the `historyData` array, the history table body, and the console when the reset button is clicked.

Fixes #36

---
*PR created automatically by Jules for task [12400567325534758938](https://jules.google.com/task/12400567325534758938) started by @chatelao*