### PR TITLE
Add visibility toggle checkboxes for uio signals in web tester

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -12,6 +12,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const exportCsvBtn = document.getElementById('exportCsv');
     const historyBody = document.getElementById('history');
     const consoleDiv = document.getElementById('console');
+    const testerTable = document.querySelector('.tester-table');
+
+    // Column visibility toggles
+    ['uio_in', 'uio_out', 'uio_oe'].forEach(col => {
+        const toggle = document.getElementById(`toggle-${col}`);
+        toggle.addEventListener('change', () => {
+            if (toggle.checked) {
+                testerTable.classList.remove(`hide-${col}`);
+            } else {
+                testerTable.classList.add(`hide-${col}`);
+            }
+        });
+    });
     const historyData = [];
 
     function logToConsole(message) {
@@ -98,6 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // uio_in
         const uioInTd = document.createElement('td');
+        uioInTd.className = 'col-uio_in';
         uioInTd.appendChild(createBitDisplay(inputs.uio_in));
         row.appendChild(uioInTd);
 
@@ -115,11 +129,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // uio_out
         const uioOutTd = document.createElement('td');
+        uioOutTd.className = 'col-uio_out';
         uioOutTd.appendChild(createBitDisplay(outputs.uio_out));
         row.appendChild(uioOutTd);
 
         // uio_oe
         const uioOeTd = document.createElement('td');
+        uioOeTd.className = 'col-uio_oe';
         uioOeTd.appendChild(createBitDisplay(outputs.uio_oe));
         row.appendChild(uioOeTd);
 

--- a/web/index.html
+++ b/web/index.html
@@ -16,13 +16,22 @@
                     <tr>
                         <th>Time</th>
                         <th>ui_in [7:0]</th>
-                        <th>uio_in [7:0]</th>
+                        <th class="col-uio_in">
+                            <input type="checkbox" id="toggle-uio_in" checked title="Toggle uio_in visibility">
+                            uio_in [7:0]
+                        </th>
                         <th>clk</th>
                         <th>rst_n</th>
                         <th>ena</th>
                         <th>uo_out [7:0]</th>
-                        <th>uio_out [7:0]</th>
-                        <th>uio_oe [7:0]</th>
+                        <th class="col-uio_out">
+                            <input type="checkbox" id="toggle-uio_out" checked title="Toggle uio_out visibility">
+                            uio_out [7:0]
+                        </th>
+                        <th class="col-uio_oe">
+                            <input type="checkbox" id="toggle-uio_oe" checked title="Toggle uio_oe visibility">
+                            uio_oe [7:0]
+                        </th>
                         <th>Action</th>
                     </tr>
                 </thead>
@@ -41,7 +50,7 @@
                                 </div>
                             </div>
                         </td>
-                        <td>
+                        <td class="col-uio_in">
                             <div class="bits-container">
                                 <div class="bits" id="uio_in">
                                     <input type="checkbox" title="7"><input type="checkbox" title="6"><input type="checkbox" title="5"><input type="checkbox" title="4"><input type="checkbox" title="3"><input type="checkbox" title="2"><input type="checkbox" title="1"><input type="checkbox" title="0">
@@ -62,7 +71,9 @@
                         </td>
                         <td class="center-cell"><input type="checkbox" id="rst_n" checked></td>
                         <td class="center-cell"><input type="checkbox" id="ena" checked></td>
-                        <td colspan="3" class="results-placeholder">Ready to send...</td>
+                        <td class="results-placeholder">Ready to send...</td>
+                        <td class="col-uio_out results-placeholder"></td>
+                        <td class="col-uio_oe results-placeholder"></td>
                         <td>
                             <button id="sendReceive">Send</button>
                             <button id="exportCsv">Export CSV</button>

--- a/web/style.css
+++ b/web/style.css
@@ -46,6 +46,25 @@ h1 {
     font-size: 0.85rem;
 }
 
+/* Column hiding styles */
+.tester-table.hide-uio_in .col-uio_in > *:not(input[type="checkbox"]),
+.tester-table.hide-uio_out .col-uio_out > *:not(input[type="checkbox"]),
+.tester-table.hide-uio_oe .col-uio_oe > *:not(input[type="checkbox"]) {
+    display: none;
+}
+
+.tester-table.hide-uio_in td.col-uio_in,
+.tester-table.hide-uio_out td.col-uio_out,
+.tester-table.hide-uio_oe td.col-uio_oe {
+    background-color: #f0f0f0;
+}
+
+.tester-table input[type="checkbox"][id^="toggle-"] {
+    margin-right: 4px;
+    vertical-align: middle;
+    cursor: pointer;
+}
+
 .input-row {
     background-color: #e7f3ff;
 }


### PR DESCRIPTION
This change introduces checkboxes in the Tiny Tapeout Web Tester interface that allow users to toggle the visibility of the uio_in, uio_out, and uio_oe columns. This helps declutter the interface when these signals are not in use. The headers remain visible to allow toggling back, while the data content is hidden using CSS. The implementation includes updates to the static HTML, the dynamic row generation in JavaScript, and the supporting CSS styles.

Fixes #40

---
*PR created automatically by Jules for task [7299699465407069634](https://jules.google.com/task/7299699465407069634) started by @chatelao*