### PR TITLE
Move Send button, style Reset, and clear table on reset

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -124,11 +124,6 @@ document.addEventListener('DOMContentLoaded', () => {
         uioOeTd.appendChild(createBitDisplay(outputs.uio_oe));
         row.appendChild(uioOeTd);
 
-        // Action placeholder
-        const actionTd = document.createElement('td');
-        actionTd.textContent = '-';
-        row.appendChild(actionTd);
-
         historyBody.prepend(row);
     }
 
@@ -369,6 +364,9 @@ document.addEventListener('DOMContentLoaded', () => {
         historyData.length = 0;
         historyBody.innerHTML = '';
         consoleDiv.textContent = '';
+        const diagramImg = document.getElementById('diagram-img');
+        diagramImg.src = '';
+        diagramImg.alt = 'Timing Diagram will appear here after first transaction';
         logToConsole('History and console cleared');
     });
 

--- a/web/index.html
+++ b/web/index.html
@@ -13,6 +13,7 @@
         <div class="panel main-panel">
             <div class="table-actions">
                 <button id="exportCsv">Export CSV</button>
+                <button id="sendReceive">Send</button>
                 <button id="clearData">Reset</button>
             </div>
             <table class="tester-table">
@@ -27,7 +28,6 @@
                         <th>uo_out [7:0]</th>
                         <th>uio_out [7:0]</th>
                         <th>uio_oe [7:0]</th>
-                        <th>Action</th>
                     </tr>
                 </thead>
                 <tbody class="input-section">
@@ -67,9 +67,6 @@
                         <td class="center-cell"><input type="checkbox" id="rst_n" checked></td>
                         <td class="center-cell"><input type="checkbox" id="ena" checked></td>
                         <td colspan="3" class="results-placeholder">Ready to send...</td>
-                        <td>
-                            <button id="sendReceive">Send</button>
-                        </td>
                     </tr>
                 </tbody>
                 <tbody id="history">

--- a/web/style.css
+++ b/web/style.css
@@ -188,11 +188,13 @@ button:hover {
 }
 
 #clearData {
-    background-color: #dc3545;
+    background-color: white;
+    color: #007bff;
+    border: 1px solid #007bff;
 }
 
 #clearData:hover {
-    background-color: #a71d2a;
+    background-color: #e7f3ff;
 }
 
 .tbd {


### PR DESCRIPTION
The "Send" button was moved from the table row to the global action bar next to "Reset". The "Reset" button was restyled to have an inverted appearance (white background, blue text, blue border) and its functionality was enhanced to clear the history table and reset the timing diagram. The "Action" column, which was only used for the Send button, was removed from the table header and rows.

Fixes #45

---
*PR created automatically by Jules for task [5361793371508673978](https://jules.google.com/task/5361793371508673978) started by @chatelao*