### PR TITLE
Integrate Testset Framework into Web Tester

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -11,9 +11,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const sendReceiveBtn = document.getElementById('sendReceive');
     const exportCsvBtn = document.getElementById('exportCsv');
     const clearDataBtn = document.getElementById('clearData');
+    const testsetSelect = document.getElementById('testsetSelect');
+    const loadTestsetBtn = document.getElementById('loadTestset');
+    const runTestsetBtn = document.getElementById('runTestset');
+    const testsetInfo = document.getElementById('testsetInfo');
     const historyBody = document.getElementById('history');
     const consoleDiv = document.getElementById('console');
     const historyData = [];
+    let currentTestset = null;
 
     function logToConsole(message) {
         const timestamp = new Date().toLocaleTimeString();
@@ -370,6 +375,128 @@ document.addEventListener('DOMContentLoaded', () => {
         historyBody.innerHTML = '';
         consoleDiv.textContent = '';
         logToConsole('History and console cleared');
+    });
+
+    async function fetchTestsets() {
+        try {
+            const response = await fetch('https://api.github.com/repos/chatelao/tt-test-framework/contents/src/data');
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+            const files = await response.json();
+
+            const yamlFiles = files.filter(file => file.name.endsWith('.yaml'));
+
+            testsetSelect.innerHTML = '<option value="">Select a testset...</option>';
+            yamlFiles.forEach(file => {
+                const option = document.createElement('option');
+                option.value = file.download_url;
+                option.textContent = file.name;
+                testsetSelect.appendChild(option);
+            });
+            logToConsole(`Fetched ${yamlFiles.length} testsets from GitHub`);
+        } catch (e) {
+            console.error('Failed to fetch testsets', e);
+            logToConsole('Failed to fetch testsets from GitHub');
+            testsetSelect.innerHTML = '<option value="">Error loading testsets</option>';
+        }
+    }
+
+    fetchTestsets();
+
+    runTestsetBtn.addEventListener('click', async () => {
+        if (!currentTestset || !currentTestset.test_steps) return;
+
+        logToConsole(`Running testset: ${currentTestset.project || 'Unnamed'}`);
+        runTestsetBtn.disabled = true;
+
+        // Initial state from UI
+        let uiVal = getBits(uiIn);
+        let uioVal = getBits(uioIn);
+        let rstVal = rstN.checked ? 1 : 0;
+        let enaVal = ena.checked ? 1 : 0;
+        const clkSelection = clk.value;
+
+        for (const step of currentTestset.test_steps) {
+            logToConsole(`Executing step: ${step.name || 'unnamed'}`);
+
+            // Update state from step values if present
+            if (step.values) {
+                if (step.values.ui_in !== undefined) uiVal = step.values.ui_in & 0xFF;
+                if (step.values.uio_in !== undefined) uioVal = step.values.uio_in & 0xFF;
+                if (step.values.rst_n !== undefined) rstVal = step.values.rst_n ? 1 : 0;
+                if (step.values.ena !== undefined) enaVal = step.values.ena ? 1 : 0;
+            }
+
+            const numCycles = step.cycles || 1;
+            for (let i = 0; i < numCycles; i++) {
+                if (clkSelection === '1/0') {
+                    performTransaction(uiVal, uioVal, 1, rstVal, enaVal);
+                    performTransaction(uiVal, uioVal, 0, rstVal, enaVal);
+                } else {
+                    const cVal = parseInt(clkSelection);
+                    performTransaction(uiVal, uioVal, cVal, rstVal, enaVal);
+                }
+                // Yield to main thread
+                await new Promise(r => setTimeout(r, 0));
+            }
+        }
+        logToConsole('Testset execution complete');
+        runTestsetBtn.disabled = false;
+    });
+
+    loadTestsetBtn.addEventListener('click', async () => {
+        const url = testsetSelect.value;
+        if (!url) {
+            alert('Please select a testset first');
+            return;
+        }
+
+        try {
+            logToConsole(`Loading testset from ${url}...`);
+            const response = await fetch(url);
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+            const yamlText = await response.text();
+
+            currentTestset = jsyaml.load(yamlText);
+            logToConsole(`Loaded testset: ${currentTestset.project || 'Unknown Project'}`);
+
+            testsetInfo.innerHTML = '';
+
+            const projectDiv = document.createElement('div');
+            const projectLabel = document.createElement('strong');
+            projectLabel.textContent = 'Project: ';
+            projectDiv.appendChild(projectLabel);
+            projectDiv.appendChild(document.createTextNode(currentTestset.project || 'N/A'));
+            testsetInfo.appendChild(projectDiv);
+
+            if (currentTestset.metadata && currentTestset.metadata.source) {
+                const sourceDiv = document.createElement('div');
+                const sourceLabel = document.createElement('strong');
+                sourceLabel.textContent = 'Source: ';
+                sourceDiv.appendChild(sourceLabel);
+                const sourceLink = document.createElement('a');
+                sourceLink.href = currentTestset.metadata.source;
+                sourceLink.target = '_blank';
+                sourceLink.textContent = currentTestset.metadata.source;
+                sourceDiv.appendChild(sourceLink);
+                testsetInfo.appendChild(sourceDiv);
+            }
+
+            if (currentTestset.test_steps) {
+                const stepsDiv = document.createElement('div');
+                const stepsLabel = document.createElement('strong');
+                stepsLabel.textContent = 'Steps: ';
+                stepsDiv.appendChild(stepsLabel);
+                stepsDiv.appendChild(document.createTextNode(currentTestset.test_steps.length));
+                testsetInfo.appendChild(stepsDiv);
+            }
+
+            runTestsetBtn.disabled = false;
+        } catch (e) {
+            console.error('Failed to load testset', e);
+            logToConsole('Failed to load testset');
+            testsetInfo.textContent = 'Error loading testset.';
+            runTestsetBtn.disabled = true;
+        }
     });
 
     logToConsole('Tiny Tapeout Web Tester Initialized');

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tiny Tapeout Web Tester</title>
     <link rel="stylesheet" href="style.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
 </head>
 <body>
     <div class="container-fluid">
@@ -77,6 +78,20 @@
                 </tbody>
             </table>
             <div class="tbd">WebSerial TBD</div>
+        </div>
+
+        <div class="panel testset-panel">
+            <h2>Testset Framework</h2>
+            <div class="testset-actions">
+                <select id="testsetSelect">
+                    <option value="">Loading testsets...</option>
+                </select>
+                <button id="loadTestset">Load</button>
+                <button id="runTestset" disabled>Run Testset</button>
+            </div>
+            <div id="testsetInfo" class="testset-info">
+                No testset loaded.
+            </div>
         </div>
 
         <div class="panel console-panel">

--- a/web/style.css
+++ b/web/style.css
@@ -195,6 +195,58 @@ button:hover {
     background-color: #a71d2a;
 }
 
+.testset-panel h2 {
+    margin-top: 0;
+    font-size: 1.1rem;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 8px;
+}
+
+.testset-actions {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+    align-items: center;
+}
+
+#testsetSelect {
+    flex-grow: 1;
+    padding: 6px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9rem;
+}
+
+#loadTestset {
+    background-color: #28a745;
+}
+
+#loadTestset:hover {
+    background-color: #218838;
+}
+
+#runTestset {
+    background-color: #fd7e14;
+}
+
+#runTestset:hover {
+    background-color: #e46a06;
+}
+
+#runTestset:disabled {
+    background-color: #ffc291;
+    cursor: not-allowed;
+}
+
+.testset-info {
+    padding: 10px;
+    background-color: #f8f9fa;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    border: 1px solid #eee;
+}
+
 .tbd {
     text-align: center;
     margin-top: 15px;


### PR DESCRIPTION
This change integrates the "tt-test-framework" into the Tiny Tapeout Web Tester. Users can now browse and select predefined testsets from the official framework repository directly within the web interface. The integration includes a fetching mechanism using the GitHub API, a YAML parser, and an execution loop that translates test steps into serial commands for the Tang Nano 4K board. The execution is handled asynchronously to prevent the UI from freezing during long-running tests. Visual verification was performed using Playwright.

Fixes #46

---
*PR created automatically by Jules for task [8248159831675666639](https://jules.google.com/task/8248159831675666639) started by @chatelao*