### PR TITLE
Add SRAM Flasher Web Tool

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@
 - [x] Initial project structure
 - [x] Web interface skeleton
 - [x] WebSerial protocol definition (TT_SERIAL.md)
+- [x] Implement SRAM Flasher web tool
 
 ## Next 5 Steps
 - [ ] Implement TT_SERIAL protocol in Cortex-M3 C firmware

--- a/web/flasher.html
+++ b/web/flasher.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tang Nano 4K SRAM Flasher</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container-fluid">
+        <h1>Tang Nano 4K SRAM Flasher</h1>
+
+        <nav class="nav-tabs">
+            <a href="index.html" class="nav-link">Web Tester</a>
+            <a href="flasher.html" class="nav-link active">SRAM Flasher</a>
+        </nav>
+
+        <div class="panel main-panel">
+            <h2>Flash to SRAM</h2>
+            <p>Select a bitstream file (.fs or .bst) to flash it to the Tang Nano 4K SRAM.</p>
+            <div class="flasher-controls">
+                <input type="file" id="bitstreamInput" accept=".bst,.fs" />
+                <button id="flashBtn" disabled>Flash to SRAM</button>
+            </div>
+        </div>
+
+        <div class="panel console-panel">
+            <h2>Flasher Console</h2>
+            <div id="console" class="console"></div>
+        </div>
+    </div>
+    <script type="module" src="flasher.js"></script>
+</body>
+</html>

--- a/web/flasher.js
+++ b/web/flasher.js
@@ -1,0 +1,53 @@
+import { openFPGALoader } from 'https://cdn.jsdelivr.net/npm/@yowasp/openfpgaloader/dist/web.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const fileInput = document.getElementById('bitstreamInput');
+    const flashBtn = document.getElementById('flashBtn');
+    const consoleDiv = document.getElementById('console');
+
+    function logToConsole(message) {
+        const timestamp = new Date().toLocaleTimeString();
+        consoleDiv.textContent += `[${timestamp}] ${message}\n`;
+        consoleDiv.scrollTop = consoleDiv.scrollHeight;
+    }
+
+    fileInput.addEventListener('change', () => {
+        flashBtn.disabled = !fileInput.files.length;
+        if (fileInput.files.length) {
+            logToConsole(`Selected file: ${fileInput.files[0].name}`);
+        }
+    });
+
+    flashBtn.addEventListener('click', async () => {
+        if (!fileInput.files.length) return;
+
+        try {
+            flashBtn.disabled = true;
+            const file = fileInput.files[0];
+            logToConsole(`Reading bitstream: ${file.name}...`);
+
+            const arrayBuffer = await file.arrayBuffer();
+            const bitstream = new Uint8Array(arrayBuffer);
+
+            logToConsole("Requesting WebUSB device (BL702)...");
+            const device = await navigator.usb.requestDevice({
+                filters: [{ vendorId: 0x0403, productId: 0x6010 }]
+            });
+
+            logToConsole("Initializing JTAG and writing to SRAM...");
+            // Redirecting openFPGALoader output to console if possible would be nice,
+            // but the basic implementation uses console.log internally often.
+            await openFPGALoader.flash(device, bitstream, { board: 'tangnano4k', target: 'sram' });
+
+            logToConsole("SRAM Flash Complete!");
+        } catch (err) {
+            logToConsole(`Error: ${err.message || err}`);
+            console.error("Flashing failed:", err);
+        } finally {
+            flashBtn.disabled = false;
+        }
+    });
+
+    logToConsole("SRAM Flasher Initialized");
+    logToConsole("Note: This tool requires a browser with WebUSB support (e.g., Chrome, Edge).");
+});

--- a/web/index.html
+++ b/web/index.html
@@ -10,6 +10,11 @@
     <div class="container-fluid">
         <h1>Tiny Tapeout Web Tester</h1>
 
+        <nav class="nav-tabs">
+            <a href="index.html" class="nav-link active">Web Tester</a>
+            <a href="flasher.html" class="nav-link">SRAM Flasher</a>
+        </nav>
+
         <div class="panel main-panel">
             <div class="table-actions">
                 <button id="exportCsv">Export CSV</button>

--- a/web/style.css
+++ b/web/style.css
@@ -14,6 +14,38 @@ body {
     max-width: 1400px;
 }
 
+.nav-tabs {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 20px;
+    border-bottom: 1px solid #ddd;
+    gap: 10px;
+}
+
+.nav-link {
+    text-decoration: none;
+    color: #65676b;
+    padding: 10px 20px;
+    border: 1px solid transparent;
+    border-bottom: none;
+    border-radius: 8px 8px 0 0;
+    font-weight: bold;
+    transition: all 0.2s;
+}
+
+.nav-link:hover {
+    background-color: #e7f3ff;
+    color: #007bff;
+}
+
+.nav-link.active {
+    color: #007bff;
+    background-color: #fff;
+    border-color: #ddd;
+    margin-bottom: -1px;
+    box-shadow: 0 -2px 4px rgba(0,0,0,0.05);
+}
+
 h1 {
     text-align: center;
     color: #050505;
@@ -244,6 +276,26 @@ button:hover {
     color: #888;
     font-style: italic;
     font-size: 0.8rem;
+}
+
+.flasher-controls {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    margin-bottom: 20px;
+}
+
+.flasher-controls input[type="file"] {
+    flex-grow: 1;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: #f8f9fa;
+}
+
+button:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
 }
 
 #history tr:nth-child(even) {


### PR DESCRIPTION
I have added a new "SRAM Flasher" tool to the Tiny Tapeout Web interface. This tool allows users to flash Gowin Tang Nano 4K bitstreams directly to SRAM from their browser using WebUSB and the `@yowasp/openfpgaloader` library.

Key changes:
- **Navigation:** Added a tabbed navigation bar at the top of both the Web Tester and the new SRAM Flasher pages for seamless switching.
- **Flasher UI:** Created `web/flasher.html` with a file selector and a flash button. It includes a dedicated status console to provide real-time feedback during the flashing process.
- **Flashing Logic:** Implemented `web/flasher.js` which handles bitstream reading, WebUSB device request (targeting the BL702 MCU), and calls the Wasm-based `openFPGALoader.flash` function.
- **Styling:** Updated `web/style.css` with a consistent look for the navigation and flasher-specific controls.
- **Roadmap:** Marked the SRAM Flasher feature as complete in `ROADMAP.md`.

Verification:
- Performed frontend verification using Playwright, confirming correct layout and navigation between pages.
- Successfully simulated the flashing process and confirmed UI responsiveness.
- Conducted a code review and addressed feedback by removing temporary development artifacts.

Fixes #51

---
*PR created automatically by Jules for task [6694010182572387337](https://jules.google.com/task/6694010182572387337) started by @chatelao*