### PR TITLE
Add static permalink feature for test projects

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const testsetSelect = document.getElementById('testsetSelect');
     const loadTestsetBtn = document.getElementById('loadTestset');
     const runTestsetBtn = document.getElementById('runTestset');
+    const copyPermalinkBtn = document.getElementById('copyPermalink');
     const testsetInfo = document.getElementById('testsetInfo');
     const historyBody = document.getElementById('history');
     const consoleDiv = document.getElementById('console');
@@ -32,6 +33,16 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     const historyData = [];
     let currentTestset = null;
+
+    function updateURLParameter(projectName) {
+        const url = new URL(window.location.href);
+        if (projectName) {
+            url.searchParams.set('project', projectName);
+        } else {
+            url.searchParams.delete('project');
+        }
+        window.history.pushState({}, '', url);
+    }
 
     function logToConsole(message) {
         const timestamp = new Date().toLocaleTimeString();
@@ -426,6 +437,15 @@ document.addEventListener('DOMContentLoaded', () => {
         logToConsole('History and console cleared');
     });
 
+    copyPermalinkBtn.addEventListener('click', () => {
+        navigator.clipboard.writeText(window.location.href).then(() => {
+            logToConsole('Permalink copied to clipboard');
+        }).catch(err => {
+            console.error('Failed to copy permalink', err);
+            logToConsole('Failed to copy permalink');
+        });
+    });
+
     async function fetchTestsets() {
         try {
             const response = await fetch('https://api.github.com/repos/chatelao/tt-test-framework/contents/src/data');
@@ -442,6 +462,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 testsetSelect.appendChild(option);
             });
             logToConsole(`Fetched ${yamlFiles.length} testsets from GitHub`);
+
+            // Handle permalink
+            const urlParams = new URLSearchParams(window.location.search);
+            const projectName = urlParams.get('project');
+            if (projectName) {
+                logToConsole(`Permalink detected for project: ${projectName}`);
+                const options = Array.from(testsetSelect.options);
+                const targetOption = options.find(opt => opt.textContent === `${projectName}.yaml`);
+                if (targetOption) {
+                    testsetSelect.value = targetOption.value;
+                    loadTestsetBtn.click();
+                } else {
+                    logToConsole(`Project ${projectName} not found in testsets`);
+                }
+            }
         } catch (e) {
             console.error('Failed to fetch testsets', e);
             logToConsole('Failed to fetch testsets from GitHub');
@@ -506,7 +541,16 @@ document.addEventListener('DOMContentLoaded', () => {
             const yamlText = await response.text();
 
             currentTestset = jsyaml.load(yamlText);
-            logToConsole(`Loaded testset: ${currentTestset.project || 'Unknown Project'}`);
+            const projectName = currentTestset.project || 'Unknown Project';
+            logToConsole(`Loaded testset: ${projectName}`);
+
+            const selectedOption = testsetSelect.options[testsetSelect.selectedIndex];
+            if (selectedOption && selectedOption.textContent.endsWith('.yaml')) {
+                const fileName = selectedOption.textContent.replace('.yaml', '');
+                updateURLParameter(fileName);
+            } else {
+                updateURLParameter(projectName);
+            }
 
             testsetInfo.innerHTML = '';
 

--- a/web/index.html
+++ b/web/index.html
@@ -104,6 +104,7 @@
                 </select>
                 <button id="loadTestset">Load</button>
                 <button id="runTestset" disabled>Run Testset</button>
+                <button id="copyPermalink">Copy Permalink</button>
             </div>
             <div id="testsetInfo" class="testset-info">
                 No testset loaded.

--- a/web/style.css
+++ b/web/style.css
@@ -289,6 +289,14 @@ button:hover {
     cursor: not-allowed;
 }
 
+#copyPermalink {
+    background-color: #6c757d;
+}
+
+#copyPermalink:hover {
+    background-color: #5a6268;
+}
+
 .testset-info {
     padding: 10px;
     background-color: #f8f9fa;


### PR DESCRIPTION
This change introduces a permalink feature to the Tiny Tapeout Web Tester, allowing users to share specific test projects via a URL. 

Key changes:
- Added a "Copy Permalink" button to `web/index.html` and styled it in `web/style.css`.
- Implemented `updateURLParameter` in `web/app.js` to synchronize the browser's address bar with the currently loaded project using `history.pushState`.
- Modified `fetchTestsets` to detect the `project` query parameter on initialization and automatically trigger the loading logic for the specified project.
- Added a click event listener for the "Copy Permalink" button that uses the Clipboard API to copy the current page URL to the user's clipboard.

The feature was verified using Playwright scripts to ensure both automatic loading via URL and manual URL updates work as expected.

Fixes #57

---
*PR created automatically by Jules for task [11675222324037473979](https://jules.google.com/task/11675222324037473979) started by @chatelao*