### PR TITLE
Link Webinterface to GitHub Pages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tiny Tapeout Web Serial for Tang Nano 4K
 
 ## Goal
-Create a Webinterface based on WebSerial for Tiny Tapeout designs running to a Tang Nano 4K.
+Create a [Webinterface](https://chatelao.github.io/tiny-tapeout-web-uart-tang-nano/) based on WebSerial for Tiny Tapeout designs running to a Tang Nano 4K.
 
 ## Default Architecture
 - **WebSerial**: The Browser communicates to the board over "WebSerial".


### PR DESCRIPTION
Linked the word "Webinterface" in the `README.md` file to the project's GitHub Pages site (`https://chatelao.github.io/tiny-tapeout-web-uart-tang-nano/`). This allows users to access the live web interface directly from the repository's overview page.

Fixes #61

---
*PR created automatically by Jules for task [890655934505710064](https://jules.google.com/task/890655934505710064) started by @chatelao*