### PR TITLE
Hide disabled columns in the timing diagram

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 testerTable.classList.add(`hide-${col}`);
             }
+            updateDiagram();
         });
     });
     const historyData = [];
@@ -196,7 +197,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const channels = ['ui_in', 'uio_in', 'clk', 'rst_n', 'ena', 'uo_out', 'uio_out', 'uio_oe'];
         const config = {};
         channels.forEach(ch => {
-            config[ch] = document.getElementById(`type-${ch}`).value;
+            let type = document.getElementById(`type-${ch}`).value;
+            const toggle = document.getElementById(`toggle-${ch}`);
+            if (toggle && !toggle.checked) {
+                type = 'hidden';
+            }
+            config[ch] = type;
         });
 
         let puml = "@startuml\n";


### PR DESCRIPTION
This change ensures that signals hidden in the data table via the column visibility checkboxes (e.g., uio_in, uio_out, uio_oe) are also automatically hidden in the generated PlantUML timing diagram. This keeps the UI views synchronized and reduces clutter in the diagram when specific signals are not of interest.

Key changes:
- Triggered a diagram refresh whenever a column visibility checkbox is toggled.
- Updated the diagram generation logic to treat signals as 'hidden' if their corresponding table toggle is unchecked.

Fixes #59

---
*PR created automatically by Jules for task [12413745654716488251](https://jules.google.com/task/12413745654716488251) started by @chatelao*