### PR TITLE
Style input signals dark red in timing diagram

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -135,11 +135,18 @@ document.addEventListener('DOMContentLoaded', () => {
         if (historyData.length === 0) return "";
 
         let puml = "@startuml\n";
-        puml += "concise \"ui_in\" as ui_in\n";
-        puml += "concise \"uio_in\" as uio_in\n";
-        puml += "binary \"clk\" as clk\n";
-        puml += "binary \"rst_n\" as rst_n\n";
-        puml += "binary \"ena\" as ena\n";
+        puml += "<style>\n";
+        puml += "timingDiagram {\n";
+        puml += "  .input {\n";
+        puml += "    LineColor DarkRed\n";
+        puml += "  }\n";
+        puml += "}\n";
+        puml += "</style>\n";
+        puml += "concise \"ui_in\" as ui_in <<input>>\n";
+        puml += "concise \"uio_in\" as uio_in <<input>>\n";
+        puml += "binary \"clk\" as clk <<input>>\n";
+        puml += "binary \"rst_n\" as rst_n <<input>>\n";
+        puml += "binary \"ena\" as ena <<input>>\n";
         puml += "concise \"uo_out\" as uo_out\n";
         puml += "concise \"uio_out\" as uio_out\n";
         puml += "concise \"uio_oe\" as uio_oe\n\n";


### PR DESCRIPTION
The timing diagram generated by the Web Tester now highlights input signals using a dark red color instead of the default green. This was achieved by:
1. Adding a `<style>` block to the PlantUML string definition in `web/app.js`.
2. Defining a `.input` class within the `timingDiagram` scope with `LineColor DarkRed`.
3. Applying the `<<input>>` stereotype to the `ui_in`, `uio_in`, `clk`, `rst_n`, and `ena` signal declarations.

Output signals (`uo_out`, `uio_out`, `uio_oe`) remain in their original green color. The changes were verified visually using a Playwright script.

Fixes #37

---
*PR created automatically by Jules for task [3144919845538444808](https://jules.google.com/task/3144919845538444808) started by @chatelao*