### PR TITLE
Add scaling control to timing diagram

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -15,6 +15,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const loadTestsetBtn = document.getElementById('loadTestset');
     const runTestsetBtn = document.getElementById('runTestset');
     const copyPermalinkBtn = document.getElementById('copyPermalink');
+    const diagramScaling = document.getElementById('diagram-scaling');
+    const diagramImg = document.getElementById('diagram-img');
     const testsetInfo = document.getElementById('testsetInfo');
     const historyBody = document.getElementById('history');
     const consoleDiv = document.getElementById('console');
@@ -445,6 +447,26 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.diagram-type').forEach(select => {
         select.addEventListener('change', updateDiagram);
     });
+
+    function applyDiagramScaling(mode) {
+        if (mode === 'details') {
+            diagramImg.classList.remove('fit-width');
+            diagramImg.classList.add('more-details');
+        } else {
+            diagramImg.classList.remove('more-details');
+            diagramImg.classList.add('fit-width');
+        }
+        localStorage.setItem('diagramScaling', mode);
+    }
+
+    diagramScaling.addEventListener('change', (e) => {
+        applyDiagramScaling(e.target.value);
+    });
+
+    // Initialize scaling from localStorage
+    const savedScaling = localStorage.getItem('diagramScaling') || 'fit';
+    diagramScaling.value = savedScaling;
+    applyDiagramScaling(savedScaling);
 
     clearDataBtn.addEventListener('click', () => {
         historyData.length = 0;

--- a/web/index.html
+++ b/web/index.html
@@ -200,6 +200,13 @@
                         <option value="hidden">Hidden</option>
                     </select>
                 </div>
+                <div class="control-group">
+                    <label for="diagram-scaling">Scaling:</label>
+                    <select id="diagram-scaling">
+                        <option value="fit" selected>Fit to Width</option>
+                        <option value="details">More Details</option>
+                    </select>
+                </div>
             </div>
             <div id="diagram-container">
                 <img id="diagram-img" alt="Timing Diagram will appear here after first transaction" />

--- a/web/style.css
+++ b/web/style.css
@@ -417,7 +417,13 @@ button:disabled {
     justify-content: center;
 }
 
-#diagram-img {
+#diagram-img.fit-width {
+    width: 100%;
+    height: auto;
+    max-height: none;
+}
+
+#diagram-img.more-details {
     max-height: 500px;
     max-width: none; /* Allow horizontal expansion */
 }


### PR DESCRIPTION
The timing diagram now supports two scaling modes: 'Fit to Width' (default), which scales the diagram to the full width of the container, and 'More Details', which restores the original scrollable view with a fixed maximum height. A new dropdown in the timing diagram controls section allows users to switch between these modes, and their choice is saved to the browser's local storage for future sessions.

Fixes #67

---
*PR created automatically by Jules for task [5367545573686312470](https://jules.google.com/task/5367545573686312470) started by @chatelao*