### PR TITLE
Style input signals as DarkRed in timing diagram

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -219,20 +219,30 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         let puml = "@startuml\n";
+        puml += "<style>\n";
+        puml += "timingDiagram {\n";
+        puml += "  .input {\n";
+        puml += "    LineColor DarkRed\n";
+        puml += "  }\n";
+        puml += "}\n";
+        puml += "</style>\n";
 
         // Definitions
         channels.forEach(ch => {
             const type = config[ch];
             if (type === 'hidden') return;
 
+            const isInput = ['ui_in', 'uio_in', 'clk', 'rst_n', 'ena'].includes(ch);
+            const stereotype = isInput ? ' <<input>>' : '';
+
             if (type === 'bits') {
                 for (let i = 7; i >= 0; i--) {
-                    puml += `binary "${ch}[${i}]" as ${ch}_${i}\n`;
+                    puml += `binary "${ch}[${i}]" as ${ch}_${i}${stereotype}\n`;
                 }
             } else if (type === 'binary') {
-                puml += `binary "${ch}" as ${ch}\n`;
+                puml += `binary "${ch}" as ${ch}${stereotype}\n`;
             } else {
-                puml += `concise "${ch}" as ${ch}\n`;
+                puml += `concise "${ch}" as ${ch}${stereotype}\n`;
             }
         });
         puml += "\n";


### PR DESCRIPTION
Styled input signals (ui_in, uio_in, clk, rst_n, ena) in the PlantUML timing diagram with a DarkRed line color to distinguish them from output signals. Verified the changes with a local Playwright script and visual inspection of the generated diagram.

Fixes #74

---
*PR created automatically by Jules for task [6211372875184844948](https://jules.google.com/task/6211372875184844948) started by @chatelao*