### PR TITLE
Change single bit dropdown labels to Show/Hide

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -148,22 +148,22 @@
                 <div class="control-group">
                     <label for="type-clk">clk:</label>
                     <select id="type-clk" class="diagram-type">
-                        <option value="binary" selected>Binary</option>
-                        <option value="hidden">Hidden</option>
+                        <option value="binary" selected>Show</option>
+                        <option value="hidden">Hide</option>
                     </select>
                 </div>
                 <div class="control-group">
                     <label for="type-rst_n">rst_n:</label>
                     <select id="type-rst_n" class="diagram-type">
-                        <option value="binary" selected>Binary</option>
-                        <option value="hidden">Hidden</option>
+                        <option value="binary" selected>Show</option>
+                        <option value="hidden">Hide</option>
                     </select>
                 </div>
                 <div class="control-group">
                     <label for="type-ena">ena:</label>
                     <select id="type-ena" class="diagram-type">
-                        <option value="binary" selected>Binary</option>
-                        <option value="hidden">Hidden</option>
+                        <option value="binary" selected>Show</option>
+                        <option value="hidden">Hide</option>
                     </select>
                 </div>
                 <div class="control-group">


### PR DESCRIPTION
Modified `web/index.html` to update the labels of the timing diagram control dropdowns for single-bit signals (clk, rst_n, ena). The options are now labeled "Show" and "Hide" instead of "Binary" and "Hidden". The underlying values (`binary` and `hidden`) remain unchanged to ensure the JavaScript logic in `web/app.js` continues to function correctly. Visual verification was performed using a Playwright script and screenshot.

Fixes #75

---
*PR created automatically by Jules for task [11539029730891118388](https://jules.google.com/task/11539029730891118388) started by @chatelao*