### PR TITLE
Improve SRAM Flasher status feedback and logging

### DIFF
--- a/web/flasher.html
+++ b/web/flasher.html
@@ -21,6 +21,7 @@
             <div class="flasher-controls">
                 <input type="file" id="bitstreamInput" accept=".bst,.fs" />
                 <button id="flashBtn" disabled>Flash to SRAM</button>
+                <span id="flasherStatus" class="status-label">Ready</span>
             </div>
         </div>
 

--- a/web/flasher.js
+++ b/web/flasher.js
@@ -1,8 +1,9 @@
-import { openFPGALoader } from 'https://cdn.jsdelivr.net/npm/@yowasp/openfpgaloader/dist/web.js';
+import { runOpenFPGALoader as openFPGALoader } from 'https://cdn.jsdelivr.net/npm/@yowasp/openfpgaloader/gen/bundle.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const fileInput = document.getElementById('bitstreamInput');
     const flashBtn = document.getElementById('flashBtn');
+    const flasherStatus = document.getElementById('flasherStatus');
     const consoleDiv = document.getElementById('console');
 
     function logToConsole(message) {
@@ -15,6 +16,9 @@ document.addEventListener('DOMContentLoaded', () => {
         flashBtn.disabled = !fileInput.files.length;
         if (fileInput.files.length) {
             logToConsole(`Selected file: ${fileInput.files[0].name}`);
+            flasherStatus.textContent = "Ready to flash";
+        } else {
+            flasherStatus.textContent = "Ready";
         }
     });
 
@@ -23,28 +27,48 @@ document.addEventListener('DOMContentLoaded', () => {
 
         try {
             flashBtn.disabled = true;
+            flashBtn.textContent = "Flashing...";
+            flasherStatus.textContent = "Reading bitstream...";
+
             const file = fileInput.files[0];
             logToConsole(`Reading bitstream: ${file.name}...`);
 
             const arrayBuffer = await file.arrayBuffer();
             const bitstream = new Uint8Array(arrayBuffer);
 
-            logToConsole("Requesting WebUSB device (BL702)...");
-            const device = await navigator.usb.requestDevice({
-                filters: [{ vendorId: 0x0403, productId: 0x6010 }]
+            flasherStatus.textContent = "Requesting device...";
+            logToConsole("Initializing JTAG and writing to SRAM...");
+
+            const filesIn = {
+                'bitstream.fs': bitstream
+            };
+            const args = ['-b', 'tangnano4k', '--write-sram', 'bitstream.fs'];
+
+            const decoder = new TextDecoder();
+            const logHandler = (bytes) => {
+                if (bytes) {
+                    const text = decoder.decode(bytes, { stream: true });
+                    logToConsole(text);
+                    if (text.includes('%')) {
+                        flasherStatus.textContent = `Writing: ${text.trim()}`;
+                    }
+                }
+            };
+
+            await openFPGALoader(args, filesIn, {
+                stdout: logHandler,
+                stderr: logHandler
             });
 
-            logToConsole("Initializing JTAG and writing to SRAM...");
-            // Redirecting openFPGALoader output to console if possible would be nice,
-            // but the basic implementation uses console.log internally often.
-            await openFPGALoader.flash(device, bitstream, { board: 'tangnano4k', target: 'sram' });
-
+            flasherStatus.textContent = "SRAM Flash Complete!";
             logToConsole("SRAM Flash Complete!");
         } catch (err) {
+            flasherStatus.textContent = "Error: Flashing failed";
             logToConsole(`Error: ${err.message || err}`);
             console.error("Flashing failed:", err);
         } finally {
             flashBtn.disabled = false;
+            flashBtn.textContent = "Flash to SRAM";
         }
     });
 

--- a/web/style.css
+++ b/web/style.css
@@ -315,7 +315,7 @@ button:hover {
     gap: 15px;
 }
 
-#statusLabel {
+#statusLabel, .status-label {
     font-size: 0.9rem;
     color: #65676b;
     font-weight: bold;


### PR DESCRIPTION
This change improves the SRAM Flasher tool by providing clear, real-time feedback to the user during the flashing process. It integrates with the YoWASP `runOpenFPGALoader` API to capture and display progress information (including percentage updates) and updates the UI to reflect the current stage of operation (e.g., "Reading bitstream...", "Requesting device...", "Writing..."). This addresses the user's concern about not knowing when the tool connects or what its current status is.

Fixes #92

---
*PR created automatically by Jules for task [17518036815230768046](https://jules.google.com/task/17518036815230768046) started by @chatelao*