### PR TITLE
Move 'Send' button to action row and remove 'Action' column

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -267,11 +267,6 @@ document.addEventListener('DOMContentLoaded', () => {
         uioOeTd.appendChild(createBitDisplay(outputs.uio_oe));
         row.appendChild(uioOeTd);
 
-        // Action placeholder
-        const actionTd = document.createElement('td');
-        actionTd.textContent = '-';
-        row.appendChild(actionTd);
-
         historyBody.prepend(row);
     }
 

--- a/web/index.html
+++ b/web/index.html
@@ -21,6 +21,7 @@
                 <button id="exportCsv">Export CSV</button>
                 <button id="importCsv">Import CSV</button>
                 <input type="file" id="importCsvFile" accept=".csv" style="display: none;">
+                <button id="sendReceive">Send</button>
                 <button id="clearData">Reset</button>
             </div>
             <div class="table-responsive">
@@ -45,7 +46,6 @@
                             <input type="checkbox" id="toggle-uio_oe" checked title="Toggle uio_oe visibility">
                             uio_oe [7:0]
                         </th>
-                        <th>Action</th>
                     </tr>
                 </thead>
                 <tbody class="input-section">
@@ -87,9 +87,6 @@
                         <td class="results-placeholder">Ready to send...</td>
                         <td class="col-uio_out results-placeholder"></td>
                         <td class="col-uio_oe results-placeholder"></td>
-                        <td>
-                            <button id="sendReceive">Send</button>
-                        </td>
                     </tr>
                 </tbody>
                 <tbody id="history">


### PR DESCRIPTION
I have moved the "Send" button from the table to the action button row above the table, as requested. 

Specifically, I:
1.  Modified `web/index.html` to move the `sendReceive` button into the `table-actions` div, placed between "Import CSV" and "Reset".
2.  Removed the "Action" column from the `tester-table` in `web/index.html` (both from the `thead` and the `input-row`).
3.  Updated the `addHistoryRow` function in `web/app.js` to no longer generate the "Action" column cell for history rows.
4.  Verified the changes by running the existing Playwright tests in `test/test_frontend.py` and capturing a new verification screenshot.

The UI now looks as requested, with the "Send" button more prominently placed in the main action area.

Fixes #96

---
*PR created automatically by Jules for task [7230879409621461146](https://jules.google.com/task/7230879409621461146) started by @chatelao*