### PR TITLE
Update simulation mode to use XOR logic for uo_out

### DIFF
--- a/test/test_frontend.py
+++ b/test/test_frontend.py
@@ -113,10 +113,17 @@ def run_test():
             expect(page.locator("#connectBtn")).to_have_text("Connect")
             expect(page.locator("#statusLabel")).to_have_text("Simulation Mode")
 
-            # 5. Perform a Send in Simulation mode
-            print("Clicking Send in simulation mode...")
+            # 5. Perform a Send in Simulation mode (XOR test)
+            print("Clicking Send in simulation mode (XOR test)...")
+            # Set ui_in to 0x55 and uio_in to 0xAA
+            page.fill("#ui_in_hex", "55")
+            page.press("#ui_in_hex", "Enter")
+            page.fill("#uio_in_hex", "AA")
+            page.press("#uio_in_hex", "Enter")
+
             page.click("#sendReceive")
-            expect(page.locator("#console")).to_contain_text("Received (Emulated): uo_out=0x10", timeout=5000)
+            # 0x55 ^ 0xAA = 0xFF
+            expect(page.locator("#console")).to_contain_text("Received (Emulated): uo_out=0xFF", timeout=5000)
 
             print("WebSerial functionality test passed!")
             browser.close()

--- a/web/app.js
+++ b/web/app.js
@@ -467,8 +467,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function mockBoard(uiValue, uioInValue, clkVal, rstVal, enaVal) {
-        // Emulate behavior: Summing ui_in and uio_in
-        const result = (uiValue + uioInValue) & 0xFF;
+        // Emulate behavior: uo_out = ui_in ^ uio_in (XOR)
+        const result = (uiValue ^ uioInValue) & 0xFF;
         return {
             uo_out: result,
             uio_out: 0,
@@ -489,7 +489,7 @@ document.addEventListener('DOMContentLoaded', () => {
             ena: enaVal
         };
 
-        logToConsole(`Sending: ui_in=0x${uiValue.toString(16).padStart(2, '0')}, uio_in=0x${uioInValue.toString(16).padStart(2, '0')}, clk=${clkVal}, rst_n=${rstVal}, ena=${enaVal}`);
+        logToConsole(`Sending: ui_in=0x${uiValue.toString(16).padStart(2, '0').toUpperCase()}, uio_in=0x${uioInValue.toString(16).padStart(2, '0').toUpperCase()}, clk=${clkVal}, rst_n=${rstVal}, ena=${enaVal}`);
 
         let outputs;
 
@@ -525,14 +525,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     uio_out: parts[3] ? parseInt(parts[3], 16) : 0,
                     uio_oe: parts[5] ? parseInt(parts[5], 16) : 0
                 };
-                logToConsole(`Received (Serial): uo_out=0x${outputs.uo_out.toString(16).padStart(2, '0')}`);
+                logToConsole(`Received (Serial): uo_out=0x${outputs.uo_out.toString(16).padStart(2, '0').toUpperCase()}`);
             } else {
                 logToConsole('Error: Serial transaction timed out');
                 outputs = { uo_out: 0, uio_out: 0, uio_oe: 0 };
             }
         } else {
             outputs = mockBoard(uiValue, uioInValue, clkVal, rstVal, enaVal);
-            logToConsole(`Received (Emulated): uo_out=0x${outputs.uo_out.toString(16).padStart(2, '0')}`);
+            logToConsole(`Received (Emulated): uo_out=0x${outputs.uo_out.toString(16).padStart(2, '0').toUpperCase()}`);
         }
 
         historyData.push({


### PR DESCRIPTION
Updates the simulation mode in the Tiny Tapeout Web Tester to use XOR logic for the output signal, matching the requested behavior. Includes test updates and UI consistency improvements.

Fixes #101

---
*PR created automatically by Jules for task [2510032128895041856](https://jules.google.com/task/2510032128895041856) started by @chatelao*