### PR TITLE
Update architecture diagram with TT wrapper signals

### DIFF
--- a/architecture.puml
+++ b/architecture.puml
@@ -17,9 +17,12 @@ Container_Boundary(soc, "GW1NSR-4C SoC (Tang Nano 4K)") {
     Component(m3, "Cortex-M3 Hard Core", "ARMv7-M", "Gowin_EMPU_M3 IP")
 
     Boundary(fabric, "FPGA Fabric") {
-        Component(apb_slots, "APB2 Slots (0x40002400)", "Register-mapped", "TT Control and Data")
+        Component(tt_wrapper, "TT APB2 Wrapper", "Register-mapped", "0x40002400")
+        Component(tt_module, "TT Module", "tt_um_minimal_echo", "Tiny Tapeout Project")
 
-        Rel(m3, apb_slots, "APB2 Expansion")
+        Rel(m3, tt_wrapper, "APB2 Expansion")
+        Rel(tt_wrapper, tt_module, "ui_in[7:0], uio_in[7:0]\nclk, rst_n, ena")
+        Rel(tt_module, tt_wrapper, "uo_out[7:0], uio_out[7:0]\nuio_oe[7:0]")
     }
 
     Component(int_flash, "Internal Flash (32KB)", "0x00000000", "Firmware (.bin)")


### PR DESCRIPTION
I have updated the `architecture.puml` file to include the specific signals from the Tiny Tapeout (TT) wrapper Verilog logic. The diagram now explicitly shows the `tt_wrapper` (renamed from `apb_slots`) and its connection to the `tt_module`, detailing the bidirectional flow of signals such as `ui_in`, `uo_out`, `uio_in`, `uio_out`, `uio_oe`, `clk`, `rst_n`, and `ena`. This provides a more accurate and detailed representation of the project's hardware architecture. I have also verified the changes by running the existing frontend tests and reviewing the PlantUML source.

Fixes #108

---
*PR created automatically by Jules for task [12920180348126708857](https://jules.google.com/task/12920180348126708857) started by @chatelao*