### PR TITLE
Update architecture.puml with flash grouping and USB/JTAG bridge

### DIFF
--- a/architecture.puml
+++ b/architecture.puml
@@ -13,30 +13,40 @@ System_Boundary(host, "Host PC") {
     Rel(browser, web_page, "Loads and runs")
 }
 
-Container_Boundary(soc, "GW1NSR-4C SoC (Tang Nano 4K)") {
-    Component(m3, "Cortex-M3 Hard Core", "ARMv7-M", "Gowin_EMPU_M3 IP")
+Boundary(board, "Tang Nano 4K Board") {
+    Component(bridge, "USB/JTAG Bridge", "BL702", "Programming & UART Interface")
 
-    Boundary(fabric, "FPGA Fabric") {
-        Component(tt_wrapper, "TT APB2 Wrapper", "Register-mapped", "0x40002400")
-        Component(tt_module, "TT Module", "tt_um_minimal_echo", "Tiny Tapeout Project")
+    Container_Boundary(soc, "GW1NSR-4C SoC (Tang Nano 4K)") {
+        Component(m3, "Cortex-M3 Hard Core", "ARMv7-M", "Gowin_EMPU_M3 IP")
 
-        Rel(tt_wrapper, tt_module, "ui_in[7:0], uio_in[7:0]\nclk, rst_n, ena")
-        Rel(tt_module, tt_wrapper, "uo_out[7:0], uio_out[7:0]\nuio_oe[7:0]")
+        Boundary(fabric, "FPGA Fabric") {
+            Component(tt_wrapper, "TT APB2 Wrapper", "Register-mapped", "0x40002400")
+            Component(tt_module, "TT Module", "tt_um_minimal_echo", "Tiny Tapeout Project")
+
+            Rel(tt_wrapper, tt_module, "ui_in[7:0], uio_in[7:0]\nclk, rst_n, ena")
+            Rel(tt_module, tt_wrapper, "uo_out[7:0], uio_out[7:0]\nuio_oe[7:0]")
+        }
+
+        Boundary(flash, "Flash Memory") {
+            Component(int_flash, "Internal Flash (32KB)", "0x00000000", "Firmware (.bin)")
+            Component(cfg_flash, "FPGA Cfg. Flash", "~200KB", "Bitstream (.fs)")
+        }
+
+        Component(int_sram, "Internal SRAM (22KB)", "0x20000000", "Stack & Fast Heap")
+        Component(uart0, "UART0 (0x40004000)", "115200 8N1", "Serial Console")
+
+        Rel(m3, int_flash, "I-Code/D-Code")
+        Rel(m3, int_sram, "System Bus")
+        Rel(m3, uart0, "APB1")
+        Rel(m3, tt_wrapper, "APB2")
+        Rel(cfg_flash, fabric, "Configures")
     }
-
-    Component(int_flash, "Internal Flash (32KB)", "0x00000000", "Firmware (.bin)")
-    Component(int_sram, "Internal SRAM (22KB)", "0x20000000", "Stack & Fast Heap")
-    Component(uart0, "UART0 (0x40004000)", "115200 8N1", "Serial Console")
-    Component(cfg_flash, "FPGA Cfg. Flash", "~200KB", "Bitstream (.fs)")
-
-    Rel(m3, int_flash, "I-Code/D-Code")
-    Rel(m3, int_sram, "System Bus")
-    Rel(m3, uart0, "APB1")
-    Rel(m3, tt_wrapper, "APB2")
-    Rel(cfg_flash, fabric, "Configures")
 }
 
 Rel(user, browser, "Interacts with")
-Rel(browser, uart0, "WebSerial", "USB-C Bridge (Pins 18/19)")
+Rel(browser, bridge, "WebSerial / WebUSB", "USB-C")
+Rel(bridge, uart0, "UART", "Pins 18/19")
+Rel(bridge, int_flash, "JTAG/SWD", "Firmware")
+Rel(bridge, cfg_flash, "JTAG", "Bitstream")
 
 @enduml


### PR DESCRIPTION
I have updated the `architecture.puml` file to better reflect the physical architecture of the Tang Nano 4K board. Specifically, I grouped the internal flash and FPGA configuration flash components into a "Flash Memory" boundary. I also added a "USB/JTAG Bridge" (BL702) component and wrapped the entire board (SoC and bridge) in a "Tang Nano 4K Board" boundary. The relationships have been updated to show how the browser interacts with the board via the bridge, which then connects to the UART and flash components for communication and programming.

I verified the changes by reading the PlantUML file and running the existing frontend tests to ensure no regressions were introduced.

Fixes #110

---
*PR created automatically by Jules for task [11469071404103898717](https://jules.google.com/task/11469071404103898717) started by @chatelao*