### PR TITLE
Add virtual input channel "cycle" to Web Tester

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -145,6 +145,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     const historyData = [];
     let currentTestset = null;
+    let cycleCount = 0;
 
     function updateURLParameter(projectName) {
         const url = new URL(window.location.href);
@@ -224,7 +225,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return container;
     }
 
-    function addHistoryRow(inputs, outputs, timestamp) {
+    function addHistoryRow(inputs, outputs, timestamp, cycle) {
         const row = document.createElement('tr');
 
         // Time
@@ -232,6 +233,12 @@ document.addEventListener('DOMContentLoaded', () => {
         timeTd.className = 'time-cell';
         timeTd.textContent = timestamp;
         row.appendChild(timeTd);
+
+        // Cycle
+        const cycleTd = document.createElement('td');
+        cycleTd.className = 'time-cell';
+        cycleTd.textContent = cycle;
+        row.appendChild(cycleTd);
 
         // ui_in
         const uiInTd = document.createElement('td');
@@ -311,7 +318,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function generatePlantUML() {
         if (historyData.length === 0) return "";
 
-        const channels = ['ui_in', 'uio_in', 'clk', 'rst_n', 'ena', 'uo_out', 'uio_out', 'uio_oe'];
+        const channels = ['cycle', 'ui_in', 'uio_in', 'clk', 'rst_n', 'ena', 'uo_out', 'uio_out', 'uio_oe'];
         const config = {};
         channels.forEach(ch => {
             let type = document.getElementById(`type-${ch}`).value;
@@ -374,7 +381,11 @@ document.addEventListener('DOMContentLoaded', () => {
                         if (type === 'binary') {
                             puml += `${ch} is ${val}\n`;
                         } else if (type === 'hex') {
-                            puml += `${ch} is "0x${val.toString(16).toUpperCase().padStart(2, '0')}"\n`;
+                            if (ch === 'cycle') {
+                                puml += `${ch} is "0x${val.toString(16).toUpperCase()}"\n`;
+                            } else {
+                                puml += `${ch} is "0x${val.toString(16).toUpperCase().padStart(2, '0')}"\n`;
+                            }
                         } else if (type === 'dec') {
                             puml += `${ch} is "${val}"\n`;
                         } else if (type === 'bin') {
@@ -512,6 +523,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     async function performTransaction(uiValue, uioInValue, clkVal, rstVal, enaVal, skipUpdate = false) {
         const timestamp = new Date().toLocaleTimeString();
+
+        if (rstVal === 0) {
+            cycleCount = 0;
+        } else if (clkVal === 1) {
+            cycleCount++;
+        }
+
         const inputs = {
             ui_in: uiValue,
             uio_in: uioInValue,
@@ -565,11 +583,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
         historyData.push({
             time: timestamp,
+            cycle: cycleCount,
             ...inputs,
             ...outputs
         });
 
-        addHistoryRow(inputs, outputs, timestamp);
+        addHistoryRow(inputs, outputs, timestamp, cycleCount);
         if (!skipUpdate) updateDiagram();
     }
 
@@ -579,12 +598,13 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        const headers = ['Time', 'ui_in', 'uio_in', 'clk', 'rst_n', 'ena', 'uo_out', 'uio_out', 'uio_oe'];
+        const headers = ['Time', 'Cycle', 'ui_in', 'uio_in', 'clk', 'rst_n', 'ena', 'uo_out', 'uio_out', 'uio_oe'];
         const csvRows = [headers.join(',')];
 
         for (const row of historyData) {
             const values = [
                 `"${row.time}"`,
+                row.cycle,
                 `0x${row.ui_in.toString(16).padStart(2, '0')}`,
                 `0x${row.uio_in.toString(16).padStart(2, '0')}`,
                 row.clk,
@@ -714,6 +734,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     clearDataBtn.addEventListener('click', () => {
         historyData.length = 0;
+        cycleCount = 0;
         historyBody.innerHTML = '';
         consoleDiv.textContent = '';
         logToConsole('History and console cleared');

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,7 @@
                 <thead>
                     <tr>
                         <th>Time</th>
+                        <th>Cycle</th>
                         <th>ui_in [7:0]</th>
                         <th class="col-uio_in">
                             <input type="checkbox" id="toggle-uio_in" checked title="Toggle uio_in visibility">
@@ -50,6 +51,7 @@
                 </thead>
                 <tbody class="input-section">
                     <tr class="input-row">
+                        <td class="time-cell">-</td>
                         <td class="time-cell">-</td>
                         <td>
                             <div class="bits-container">
@@ -126,6 +128,14 @@
         <div class="panel diagram-panel">
             <h2>Timing Diagram</h2>
             <div class="diagram-controls">
+                <div class="control-group">
+                    <label for="type-cycle">cycle:</label>
+                    <select id="type-cycle" class="diagram-type">
+                        <option value="dec" selected>Dec</option>
+                        <option value="hex">Hex</option>
+                        <option value="hidden">Hidden</option>
+                    </select>
+                </div>
                 <div class="control-group">
                     <label for="type-ui_in">ui_in:</label>
                     <select id="type-ui_in" class="diagram-type">


### PR DESCRIPTION
This PR adds a virtual "Cycle" input channel to the Tiny Tapeout Web Tester's history table and timing diagram. The cycle counter tracks the number of clock pulses since the beginning of the simulation or the most recent reset (when `rst_n` is low).

Key changes:
- **UI:** A new "Cycle" column is now visible in the history table, immediately to the right of the timestamp.
- **Logic:** The `cycleCount` variable in `web/app.js` is automatically managed: it resets to 0 if `rst_n` is low and increments if `clk` is high during a transaction.
- **Timing Diagram:** A new `cycle` channel is added to the PlantUML diagram generation. Users can choose to show it in Decimal, Hex, or hide it entirely via the diagram controls.
- **Data Export:** The exported CSV files now include a `Cycle` column for better data analysis.

Verified by:
1. Running `test/test_frontend.py` to ensure no regressions in existing WebSerial/Simulation logic.
2. Creating and running `test/verify_cycle_counter.py` to specifically validate the cycle counting and reset behavior.
3. Visual inspection of the UI and generated diagrams via Playwright screenshots.

Fixes #120

---
*PR created automatically by Jules for task [5294109903085135083](https://jules.google.com/task/5294109903085135083) started by @chatelao*