### PR TITLE
Fix unreliable XOR/WASM switching in Web Tester

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -27,6 +27,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const statusLabel = document.getElementById('statusLabel');
     const useFullWasm = document.getElementById('useFullWasm');
 
+    // Initialize Use Full WASM from localStorage
+    const savedWasmPreference = localStorage.getItem('useFullWasm');
+    if (savedWasmPreference !== null) {
+        useFullWasm.checked = savedWasmPreference === 'true';
+    }
+
+    useFullWasm.addEventListener('change', () => {
+        localStorage.setItem('useFullWasm', useFullWasm.checked);
+        logToConsole(`Use Full FP8 WASM: ${useFullWasm.checked}`);
+    });
+
     let port = null;
     let reader = null;
     let writer = null;
@@ -481,14 +492,37 @@ document.addEventListener('DOMContentLoaded', () => {
     let digitalTwin = null;
     let wasmReady = false;
 
+    function initDigitalTwin() {
+        if (typeof Module !== 'undefined' && Module.DigitalTwin && !wasmReady) {
+            try {
+                digitalTwin = new Module.DigitalTwin();
+                wasmReady = true;
+                logToConsole('Full FP8 WASM Module initialized and DigitalTwin created');
+                return true;
+            } catch (e) {
+                console.error('Failed to create DigitalTwin', e);
+            }
+        }
+        return false;
+    }
+
     // The WASM module initialized by digital_twin_Full.js
     if (typeof Module !== 'undefined') {
-        Module['onRuntimeInitialized'] = () => {
-            logToConsole('Full FP8 WASM Module initialized');
-            digitalTwin = new Module.DigitalTwin();
-            wasmReady = true;
-        };
+        if (!initDigitalTwin()) {
+            Module['onRuntimeInitialized'] = () => {
+                initDigitalTwin();
+            };
+        }
     }
+
+    // Fallback check for WASM readiness
+    const wasmCheckInterval = setInterval(() => {
+        if (wasmReady) {
+            clearInterval(wasmCheckInterval);
+        } else {
+            initDigitalTwin();
+        }
+    }, 500);
 
     function mockBoard(uiValue, uioInValue, clkVal, rstVal, enaVal) {
         if (useFullWasm.checked && wasmReady && digitalTwin) {
@@ -737,6 +771,22 @@ document.addEventListener('DOMContentLoaded', () => {
         cycleCount = 0;
         historyBody.innerHTML = '';
         consoleDiv.textContent = '';
+
+        // Reset WASM DigitalTwin state if available
+        if (digitalTwin) {
+            try {
+                // Perform a hard reset in simulation
+                digitalTwin.set_rst_n(false);
+                digitalTwin.step();
+                digitalTwin.step();
+                digitalTwin.set_rst_n(true);
+                digitalTwin.step();
+                logToConsole('Simulation state reset');
+            } catch (e) {
+                console.error('Failed to reset DigitalTwin', e);
+            }
+        }
+
         logToConsole('History and console cleared');
     });
 


### PR DESCRIPTION
This change addresses the "unreliable" behavior when switching between XOR and WASM simulations in the Web Tester. 

Key improvements:
1. **Robust WASM Initialization**: The `DigitalTwin` instance is now created as soon as the WASM module is ready, regardless of the script loading order, using a multi-pronged approach (immediate check, `onRuntimeInitialized` hook, and a short-lived polling interval).
2. **State Synchronization**: Added a logical reset sequence to the WASM simulation whenever the 'Reset' (clear history) button is clicked. This ensures that the simulation starts from a clean state, preventing carry-over effects from previous interactions.
3. **Persistence**: The 'Use Full FP8 WASM' checkbox state is now saved to `localStorage`, so the user's preference is maintained across page reloads.
4. **Visibility**: Added essential logging to the browser console to help debug simulation state transitions.

Verified with Playwright-based frontend tests and visual inspection of the UI.

Fixes #124

---
*PR created automatically by Jules for task [16441522895890571583](https://jules.google.com/task/16441522895890571583) started by @chatelao*