### PR TITLE
Add expected VCCIO voltage per bank to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ The Tiny Tapeout Web Serial REPL is accessible via the Cortex-M3 UART0 periphera
 
 ### Available Header Pins
 
-| Bank | Pins |
-| :--- | :--- |
-| **Bank 0** | 9 (DONE) |
-| **Bank 1** | 39, 40, 41, 42, 43, 44, 46 |
-| **Bank 2** | 33 |
-| **Bank 3** | 13, 16, 17, 20, 21, 22, 23 |
+| Bank | Pins | Expected Voltage (VCCIO) |
+| :--- | :--- | :--- |
+| **Bank 0** | 9 (DONE) | 1.8V |
+| **Bank 1** | 39, 40, 41, 42, 43, 44, 46 | 1.8V |
+| **Bank 2** | 33 | 1.8V |
+| **Bank 3** | 13, 16, 17, 20, 21, 22, 23 | 1.8V |
 
-*Note: JTAG and Flash pins should be avoided for general use to maintain programmability.*
+*Note: JTAG and Flash pins should be avoided for general use to maintain programmability. While the GW1NSR supports multiple I/O standards, this project's default configuration sets all VCCIO banks to 1.8V.*
 
 ## IP Core Configuration (Gowin EDA)
 


### PR DESCRIPTION
This change adds a new 'Expected Voltage (VCCIO)' column to the 'Available Header Pins' table in the README.md. Based on the project's implementation reports (tang_nano_4k_tt_uart.pin.html and tang_nano_4k_tt_uart.power.html), all four banks are configured for 1.8V operation. A footnote was also added to clarify that while the hardware supports multiple standards, the default for this project is 1.8V. Verifications were performed using the existing frontend tests to ensure documentation changes didn't affect the site's layout or functionality.

Fixes #126

---
*PR created automatically by Jules for task [14678802075823462114](https://jules.google.com/task/14678802075823462114) started by @chatelao*