### PR TITLE
Implement 0...255 Input Sweep Functionality

### DIFF
--- a/test/test_frontend.py
+++ b/test/test_frontend.py
@@ -125,7 +125,26 @@ def run_test():
             # 0x55 ^ 0xAA = 0xFF
             expect(page.locator("#console")).to_contain_text("Received (Emulated): uo_out=0xFF", timeout=5000)
 
-            print("WebSerial functionality test passed!")
+            # 6. Test Sweep 0...255 functionality
+            print("Clicking 0...255 sweep button...")
+            # Switch clk to 1 or 0 to have exactly 256 transactions
+            page.select_option("#clk", "1")
+
+            # Count current history rows
+            initial_history_count = page.locator("#history tr").count()
+            print(f"Initial history count: {initial_history_count}")
+
+            page.click("#sweepInputs")
+
+            # Wait for sweep to complete
+            expect(page.locator("#console")).to_contain_text("Sweep complete (256 cycles added)", timeout=10000)
+
+            # Verify history count increased by 256
+            final_history_count = page.locator("#history tr").count()
+            print(f"Final history count: {final_history_count}")
+            assert final_history_count == initial_history_count + 256
+
+            print("WebSerial functionality and sweep test passed!")
             browser.close()
     finally:
         os.kill(server_process.pid, signal.SIGTERM)

--- a/web/app.js
+++ b/web/app.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const clk = document.getElementById('clk');
     const rstN = document.getElementById('rst_n');
     const ena = document.getElementById('ena');
+    const sweepInputsBtn = document.getElementById('sweepInputs');
     const sendReceiveBtn = document.getElementById('sendReceive');
     const exportCsvBtn = document.getElementById('exportCsv');
     const importCsvBtn = document.getElementById('importCsv');
@@ -682,6 +683,34 @@ document.addEventListener('DOMContentLoaded', () => {
             const clkVal = parseInt(clkSelection);
             await performTransaction(uiValue, uioInValue, clkVal, rstVal, enaVal);
         }
+    });
+
+    sweepInputsBtn.addEventListener('click', async () => {
+        sweepInputsBtn.disabled = true;
+        const rstVal = rstN.checked ? 1 : 0;
+        const enaVal = ena.checked ? 1 : 0;
+        const clkSelection = clk.value;
+
+        logToConsole("Starting 0...255 sweep...");
+
+        for (let i = 0; i < 256; i++) {
+            if (clkSelection === '1/0') {
+                await performTransaction(i, i, 1, rstVal, enaVal, true);
+                await performTransaction(i, i, 0, rstVal, enaVal, true);
+            } else {
+                const clkVal = parseInt(clkSelection);
+                await performTransaction(i, i, clkVal, rstVal, enaVal, true);
+            }
+
+            // Yield to main thread every 16 iterations
+            if (i % 16 === 0) {
+                await new Promise(r => setTimeout(r, 0));
+            }
+        }
+
+        updateDiagram();
+        logToConsole("Sweep complete (256 cycles added)");
+        sweepInputsBtn.disabled = false;
     });
 
     async function importFromCsv(file) {

--- a/web/index.html
+++ b/web/index.html
@@ -21,6 +21,7 @@
                 <button id="exportCsv">Export CSV</button>
                 <button id="importCsv">Import CSV</button>
                 <input type="file" id="importCsvFile" accept=".csv" style="display: none;">
+                <button id="sweepInputs">0...255</button>
                 <button id="sendReceive">Send</button>
                 <button id="clearData">Reset</button>
             </div>


### PR DESCRIPTION
The "0...255" sweep button allows users to quickly test a range of inputs by iterating through all 256 possible values for `ui_in` and `uio_in` simultaneously. The implementation handles different clock configurations and ensures the browser remains responsive during the operation. An automated test confirms that clicking the button correctly adds 256 cycles to the history.

Fixes #129

---
*PR created automatically by Jules for task [15351018416435427468](https://jules.google.com/task/15351018416435427468) started by @chatelao*