### PR TITLE
Add Dynamic WASM Engine Selection to Web Simulator

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1,3 +1,56 @@
+// Initialize WASM Engine dynamic loading
+(function() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const wasmParam = urlParams.get('wasm');
+
+    // Security check: validate wasmParam
+    let wasmEngine = 'default';
+    if (wasmParam && /^tt\d+$/.test(wasmParam)) {
+        wasmEngine = wasmParam;
+    }
+
+    const config = {
+        locateFile: function(path) {
+            if (path.endsWith('.wasm')) {
+                if (wasmEngine === 'default') {
+                    return path; // Local file
+                } else {
+                    // Use jsdelivr CDN for correct MIME type
+                    return `https://cdn.jsdelivr.net/gh/chatelao/tt-test-framework@main/wasm/${wasmEngine}.wasm`;
+                }
+            }
+            return path;
+        }
+    };
+
+    const script = document.createElement('script');
+    if (wasmEngine === 'default') {
+        window.Module = config;
+        script.src = 'digital_twin_Full.js';
+    } else {
+        // Use jsdelivr CDN for correct MIME type
+        script.src = `https://cdn.jsdelivr.net/gh/chatelao/tt-test-framework@main/wasm/${wasmEngine}.js`;
+        script.onload = () => {
+            const factory = window[wasmEngine];
+            if (typeof factory === 'function') {
+                factory(config).then(instance => {
+                    // Log before merge
+                    console.log(`WASM ${wasmEngine} instance created`);
+                    // Merge instance into window.Module to keep references
+                    window.Module = Object.assign(window.Module || {}, instance);
+                    if (window.Module.onRuntimeInitialized) {
+                        window.Module.onRuntimeInitialized();
+                    }
+                });
+            } else {
+                console.error(`Factory window[${wasmEngine}] not found`);
+            }
+        };
+    }
+    document.head.appendChild(script);
+    window.currentWasmEngine = wasmEngine;
+})();
+
 document.addEventListener('DOMContentLoaded', () => {
     const uiIn = document.getElementById('ui_in').querySelectorAll('input');
     const uioIn = document.getElementById('uio_in').querySelectorAll('input');
@@ -26,6 +79,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const connectBtn = document.getElementById('connectBtn');
     const statusLabel = document.getElementById('statusLabel');
     const useFullWasm = document.getElementById('useFullWasm');
+    const wasmEngineSelect = document.getElementById('wasmEngineSelect');
+
+    // Set dropdown value from current URL
+    wasmEngineSelect.value = window.currentWasmEngine;
+
+    wasmEngineSelect.addEventListener('change', () => {
+        const url = new URL(window.location.href);
+        const selectedWasm = wasmEngineSelect.value;
+        if (selectedWasm === 'default') {
+            url.searchParams.delete('wasm');
+        } else {
+            url.searchParams.set('wasm', selectedWasm);
+        }
+        window.location.href = url.toString();
+    });
 
     // Initialize Use Full WASM from localStorage
     const savedWasmPreference = localStorage.getItem('useFullWasm');
@@ -35,7 +103,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     useFullWasm.addEventListener('change', () => {
         localStorage.setItem('useFullWasm', useFullWasm.checked);
-        logToConsole(`Use Full FP8 WASM: ${useFullWasm.checked}`);
+        logToConsole(`Use WASM Simulation: ${useFullWasm.checked}`);
     });
 
     let port = null;
@@ -493,14 +561,17 @@ document.addEventListener('DOMContentLoaded', () => {
     let wasmReady = false;
 
     function initDigitalTwin() {
-        if (typeof Module !== 'undefined' && Module.DigitalTwin && !wasmReady) {
-            try {
-                digitalTwin = new Module.DigitalTwin();
-                wasmReady = true;
-                logToConsole('Full FP8 WASM Module initialized and DigitalTwin created');
-                return true;
-            } catch (e) {
-                console.error('Failed to create DigitalTwin', e);
+        if (typeof Module !== 'undefined' && !wasmReady) {
+            const DigitalTwinClass = Module.DigitalTwin || Module.ProjectWasm;
+            if (DigitalTwinClass) {
+                try {
+                    digitalTwin = new DigitalTwinClass();
+                    wasmReady = true;
+                    logToConsole(`WASM Simulation initialized: ${window.currentWasmEngine}`);
+                    return true;
+                } catch (e) {
+                    console.error('Failed to create DigitalTwin', e);
+                }
             }
         }
         return false;
@@ -520,7 +591,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (wasmReady) {
             clearInterval(wasmCheckInterval);
         } else {
-            initDigitalTwin();
+            if (initDigitalTwin()) {
+                clearInterval(wasmCheckInterval);
+            }
         }
     }, 500);
 
@@ -798,6 +871,51 @@ document.addEventListener('DOMContentLoaded', () => {
             logToConsole('Failed to copy permalink');
         });
     });
+
+    async function fetchWasmEngines() {
+        try {
+            logToConsole('Fetching WASM engines and project titles from GitHub...');
+            // Fetch WASM files
+            const wasmFilesResponse = await fetch('https://api.github.com/repos/chatelao/tt-test-framework/contents/wasm');
+            if (!wasmFilesResponse.ok) throw new Error(`HTTP error fetching wasm! status: ${wasmFilesResponse.status}`);
+            const wasmFiles = await wasmFilesResponse.json();
+            const engines = wasmFiles.filter(f => f.name.endsWith('.js')).map(f => f.name.replace('.js', ''));
+
+            // Fetch data files for titles
+            const dataFilesResponse = await fetch('https://api.github.com/repos/chatelao/tt-test-framework/contents/src/data');
+            if (!dataFilesResponse.ok) throw new Error(`HTTP error fetching data! status: ${dataFilesResponse.status}`);
+            const dataFiles = await dataFilesResponse.json();
+
+            // Map project number to title (e.g. tt3990 -> fp8_mul)
+            const titleMap = {};
+            dataFiles.forEach(f => {
+                if (f.name.endsWith('.yaml')) {
+                    const match = f.name.match(/^(tt\d+)[_-](.+)\.yaml$/);
+                    if (match) {
+                        titleMap[match[1]] = match[2];
+                    }
+                }
+            });
+
+            // Populate dropdown
+            engines.forEach(engine => {
+                const option = document.createElement('option');
+                option.value = engine;
+                const title = titleMap[engine] || '';
+                option.textContent = `${engine} ${title}`.trim();
+                wasmEngineSelect.appendChild(option);
+            });
+
+            // Ensure the selection is restored after populating
+            wasmEngineSelect.value = window.currentWasmEngine;
+            logToConsole(`Fetched ${engines.length} WASM engines`);
+        } catch (e) {
+            console.error('Failed to fetch WASM engines', e);
+            logToConsole('Failed to fetch WASM engines from GitHub');
+        }
+    }
+
+    fetchWasmEngines();
 
     async function fetchTestsets() {
         try {

--- a/web/index.html
+++ b/web/index.html
@@ -99,9 +99,14 @@
             <div class="serial-controls">
                 <button id="connectBtn">Connect</button>
                 <span id="statusLabel">Simulation Mode</span>
-                <label class="wasm-toggle">
-                    <input type="checkbox" id="useFullWasm"> Use Full FP8 WASM
-                </label>
+                <div class="wasm-controls">
+                    <select id="wasmEngineSelect">
+                        <option value="default">Default (Built-in)</option>
+                    </select>
+                    <label class="wasm-toggle">
+                        <input type="checkbox" id="useFullWasm"> Use WASM Simulation
+                    </label>
+                </div>
             </div>
         </div>
 
@@ -230,7 +235,6 @@
             </div>
         </div>
     </div>
-    <script src="digital_twin_Full.js"></script>
     <script src="app.js"></script>
 </body>
 </html>

--- a/web/style.css
+++ b/web/style.css
@@ -313,6 +313,26 @@ button:hover {
     justify-content: center;
     align-items: center;
     gap: 15px;
+    flex-wrap: wrap;
+}
+
+.wasm-controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: #e7f3ff;
+    padding: 5px 15px;
+    border-radius: 20px;
+    border: 1px solid #cce4ff;
+}
+
+#wasmEngineSelect {
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+    background: white;
+    font-size: 0.85rem;
+    font-family: inherit;
 }
 
 #statusLabel, .status-label {


### PR DESCRIPTION
This change introduces a user-friendly way to switch between different Tiny Tapeout WASM simulations directly from the web interface. 

Key improvements:
- **Dynamic Discovery**: The simulator now automatically lists all projects available in the `chatelao/tt-test-framework` repository by combining WASM engine files with their corresponding YAML data titles.
- **Secure Loading**: Remote assets are served via the JSDelivr CDN, ensuring correct MIME types and improved reliability compared to raw GitHub links.
- **Robust Integration**: The application validates project identifiers and handles variations in Emscripten-generated class names (supporting both `DigitalTwin` and `ProjectWasm`).
- **Persistent Selection**: The selected engine is preserved across reloads via a URL parameter, facilitating easy sharing of specific simulation environments.

Fixes #127

---
*PR created automatically by Jules for task [11310112886581677273](https://jules.google.com/task/11310112886581677273) started by @chatelao*