### PR TITLE
Reorder web tester page sections

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -111,26 +111,6 @@
             </div>
         </div>
 
-        <div class="panel testset-panel">
-            <h2>Testset Framework</h2>
-            <div class="testset-actions">
-                <select id="testsetSelect">
-                    <option value="">Loading testsets...</option>
-                </select>
-                <button id="loadTestset">Load</button>
-                <button id="runTestset" disabled>Run Testset</button>
-                <button id="copyPermalink">Copy Permalink</button>
-            </div>
-            <div id="testsetInfo" class="testset-info">
-                No testset loaded.
-            </div>
-        </div>
-
-        <div class="panel console-panel">
-            <h2>Serial Console</h2>
-            <div id="console" class="console"></div>
-        </div>
-
         <div class="panel diagram-panel">
             <h2>Timing Diagram</h2>
             <div class="diagram-controls">
@@ -233,6 +213,26 @@
             </div>
             <div id="diagram-container">
                 <img id="diagram-img" alt="Timing Diagram will appear here after first transaction" />
+            </div>
+        </div>
+
+        <div class="panel console-panel">
+            <h2>Serial Console</h2>
+            <div id="console" class="console"></div>
+        </div>
+
+        <div class="panel testset-panel">
+            <h2>Testset Framework</h2>
+            <div class="testset-actions">
+                <select id="testsetSelect">
+                    <option value="">Loading testsets...</option>
+                </select>
+                <button id="loadTestset">Load</button>
+                <button id="runTestset" disabled>Run Testset</button>
+                <button id="copyPermalink">Copy Permalink</button>
+            </div>
+            <div id="testsetInfo" class="testset-info">
+                No testset loaded.
             </div>
         </div>
     </div>


### PR DESCRIPTION
This change reorders the main sections of the Tiny Tapeout Web Tester interface. The Testset Framework section is now at the bottom of the page, and the Serial Console is located directly above it. This was achieved by reordering the corresponding `<div>` elements in `web/index.html`. Functional integrity was verified by running existing frontend tests and visual verification with screenshots.

Fixes #143

---
*PR created automatically by Jules for task [2342563088408742487](https://jules.google.com/task/2342563088408742487) started by @chatelao*