### PR TITLE
Add Random Input Button to Web Tester

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -67,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const rstN = document.getElementById('rst_n');
     const ena = document.getElementById('ena');
     const sweepInputsBtn = document.getElementById('sweepInputs');
+    const randomInputBtn = document.getElementById('randomInput');
     const sendReceiveBtn = document.getElementById('sendReceive');
     const exportCsvBtn = document.getElementById('exportCsv');
     const importCsvBtn = document.getElementById('importCsv');
@@ -787,6 +788,28 @@ document.addEventListener('DOMContentLoaded', () => {
             URL.revokeObjectURL(url);
         }, 100);
     }
+
+    randomInputBtn.addEventListener('click', async () => {
+        const uiValue = Math.floor(Math.random() * 256);
+        const uioInValue = Math.floor(Math.random() * 256);
+
+        uiInHex.value = uiValue.toString(16).padStart(2, '0').toUpperCase();
+        uioInHex.value = uioInValue.toString(16).padStart(2, '0').toUpperCase();
+        updateBitsFromHex(uiInHex, uiIn);
+        updateBitsFromHex(uioInHex, uioIn);
+
+        const rstVal = rstN.checked ? 1 : 0;
+        const enaVal = ena.checked ? 1 : 0;
+        const clkSelection = clk.value;
+
+        if (clkSelection === '1/0') {
+            await performTransaction(uiValue, uioInValue, 1, rstVal, enaVal);
+            await performTransaction(uiValue, uioInValue, 0, rstVal, enaVal);
+        } else {
+            const clkVal = parseInt(clkSelection);
+            await performTransaction(uiValue, uioInValue, clkVal, rstVal, enaVal);
+        }
+    });
 
     sendReceiveBtn.addEventListener('click', async () => {
         const uiValue = getBits(uiIn);

--- a/web/index.html
+++ b/web/index.html
@@ -22,6 +22,7 @@
                 <button id="importCsv">Import CSV</button>
                 <input type="file" id="importCsvFile" accept=".csv" style="display: none;">
                 <button id="sweepInputs">0...255</button>
+                <button id="randomInput">Random</button>
                 <button id="sendReceive">Send</button>
                 <button id="clearData">Reset</button>
             </div>


### PR DESCRIPTION
I have added a "Random" button to the Tiny Tapeout Web Tester's main panel. When clicked, this button:
- Generates a random 8-bit integer (0-255) for both `ui_in` and `uio_in`.
- Updates the hexadecimal input fields and bit checkboxes in the UI.
- Executes the transaction by calling `performTransaction`, which handles the current clock, reset, and enable states (including toggling the clock if '1/0' is selected).

I verified the changes by:
1. Reading the modified `web/index.html` and `web/app.js` files.
2. Running the existing frontend test suite (`python3 test/test_frontend.py`), which passed.
3. Creating a Playwright verification script that took a screenshot of the new button in action, showing it correctly updates the UI and generates history rows with random values.
4. Requesting and receiving a positive code review.

Fixes #146

---
*PR created automatically by Jules for task [15761705445387026584](https://jules.google.com/task/15761705445387026584) started by @chatelao*