### PR TITLE
Add Project 3647 (2x2 Systolic Array)

### DIFF
--- a/check_3647.py
+++ b/check_3647.py
@@ -1,0 +1,47 @@
+import subprocess
+import time
+import os
+import signal
+import sys
+from playwright.sync_api import sync_playwright
+
+def check_project():
+    # Kill any existing server on port 8000
+    subprocess.run(["fuser", "-k", "8000/tcp"], stderr=subprocess.DEVNULL)
+
+    server_process = subprocess.Popen(
+        ["python3", "-m", "http.server", "8000", "--directory", "web"],
+        stdout=sys.stdout,
+        stderr=sys.stderr
+    )
+    time.sleep(2)
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page()
+            page.goto("http://localhost:8000")
+
+            # Wait for dropdown to populate
+            try:
+                page.wait_for_selector("#wasmEngineSelect option[value='tt3647']", timeout=10000, state="attached")
+            except:
+                pass
+
+            options = page.locator("#wasmEngineSelect option").all_inner_texts()
+            print("WASM Options:", options)
+
+            values = page.locator("#wasmEngineSelect option").all_attrs()
+            print("WASM Values:", [v['value'] for v in values])
+
+            testset_options = page.locator("#testsetSelect option").all_inner_texts()
+            print("Testset Options:", testset_options)
+
+            browser.close()
+    except Exception as e:
+        print(f"Error: {e}")
+    finally:
+        os.kill(server_process.pid, signal.SIGTERM)
+
+if __name__ == "__main__":
+    check_project()

--- a/check_3647_testset.py
+++ b/check_3647_testset.py
@@ -1,0 +1,42 @@
+import subprocess
+import time
+import os
+import signal
+import sys
+from playwright.sync_api import sync_playwright
+
+def check_project():
+    # Kill any existing server on port 8000
+    subprocess.run(["fuser", "-k", "8000/tcp"], stderr=subprocess.DEVNULL)
+
+    server_process = subprocess.Popen(
+        ["python3", "-m", "http.server", "8000", "--directory", "web"],
+        stdout=sys.stdout,
+        stderr=sys.stderr
+    )
+    time.sleep(2)
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page()
+            page.goto("http://localhost:8000")
+
+            # Wait for testsets to load
+            page.wait_for_selector("#testsetSelect option:nth-child(5)", timeout=10000)
+
+            testset_options = page.locator("#testsetSelect option").all_inner_texts()
+            print("Testset Options count:", len(testset_options))
+            if "tt3647_systolic.yaml" in testset_options:
+                print("tt3647_systolic.yaml is PRESENT")
+            else:
+                print("tt3647_systolic.yaml is MISSING")
+
+            browser.close()
+    except Exception as e:
+        print(f"Error: {e}")
+    finally:
+        os.kill(server_process.pid, signal.SIGTERM)
+
+if __name__ == "__main__":
+    check_project()

--- a/src/src/bf16_add.v
+++ b/src/src/bf16_add.v
@@ -1,0 +1,257 @@
+/* Copyright (c) 2026, Julia Desmazes. All rights reserved.
+
+  This work is licensed under the Creative Commons Attribution-NonCommercial
+  4.0 International License.
+
+  This code is provided "as is" without any express or implied warranties.
+
+
+  Bfloat16 addition
+  c = a+b
+
+  a = { s_a, e_a, m_a }
+  b = { s_b, e_b, m_b }
+
+*/
+module bf16_add #(
+        localparam int E = 8,
+        localparam int M = 7
+)
+(
+        input wire sa_i,
+        input wire [E-1:0] ea_i,
+        input wire [M-1:0] ma_i,
+
+        input wire sb_i,
+        input wire [E-1:0] eb_i,
+        input wire [M-1:0] mb_i,
+
+
+        output wire s_o,
+        output wire [E-1:0] e_o,
+        output wire [M-1:0] m_o
+);
+
+/* Internally the addition is performed on
+   z = x + y
+   with x >= to y
+  this is the swapped version of a and b */
+
+/* ----------------
+   compare and swap
+   ---------------- */
+//exponent
+wire [E-1:0] ex, ey, exy_diff;
+wire [M-1:0] mx, my;
+wire         sx, sy_unused;
+wire [E-1:0] eab_diff, eba_diff;
+wire         eab_diff_carry, eba_diff_carry_unused;
+
+assign {eab_diff_carry, eab_diff} = ea_i - eb_i;
+assign {eba_diff_carry_unused, eba_diff} = eb_i - ea_i;
+
+assign exy_diff = ~eab_diff_carry ? eab_diff: eba_diff;
+assign {ex, ey} = ~eab_diff_carry ? {ea_i, eb_i}: {eb_i, ea_i};
+assign {mx, my} = ~eab_diff_carry ? {ma_i, mb_i}: {mb_i, ma_i};
+assign {sx, sy_unused} = ~eab_diff_carry ? {sa_i, sb_i}: {sb_i, sa_i};
+
+// equality check, parallel check to determine close path sign for special
+// case where N - N / -N + N = +0
+wire mab_eq, exy_eq, xy_eq;
+assign mab_eq = ma_i == mb_i; // if they are equal, we don't care about swap
+assign exy_eq = ea_i == eb_i; // 1 = equal, 0 = not equal, also don't care about swap if they are equal
+assign xy_eq  = mab_eq & exy_eq;
+
+// identify corner cases :
+// +/- zero
+wire x_nzero, y_nzero;
+assign {x_nzero, y_nzero }  = {|ex, |ey};
+
+/* --------
+   far path
+   -------- */
+// stupidly expensive shifter made a little cheaper by the fact we only need
+// p+1 bits since we are doing a round to zero, we can discard the sticky bit
+logic [M+1:0] my_shift;
+
+// if y is 0 correct hidden bit to prevent wrong exponent correction
+always @(*) begin
+        case(exy_diff)
+                'd0: my_shift = {y_nzero, my, 1'b0};
+                'd1: my_shift = {1'b0, y_nzero, my};
+                'd2: my_shift = {2'b0, y_nzero, my[M-1:1]};
+                'd3: my_shift = {3'b0, y_nzero, my[M-1:2]};
+                'd4: my_shift = {4'b0, y_nzero, my[M-1:3]};
+                'd5: my_shift = {5'b0, y_nzero, my[M-1:4]};
+                'd6: my_shift = {6'b0, y_nzero, my[M-1:5]};
+                'd7: my_shift = {7'b0, y_nzero, my[M-1]};
+                'd8: my_shift = {8'b0, y_nzero};
+                default: my_shift = {9'b0}; // 9+, full shift out due to insuficient precision p = 8
+        endcase
+end
+
+// operation can be either positive or negative: m_r = m_x +/- m_y
+// since we won't be doing the common rouding post normalization to save on
+// the need to have a W+E wide adder, our addition will be done on p+1 bits
+// unlike the p bits commonly found in the literature
+wire op_sub;
+wire [M+1:0] mr;
+wire [M+1:0] my_shift_neg_comp;
+wire [M+1:0] my_shift_neg;
+wire         my_shift_neg_carry_unused;
+
+wire mr_carry;
+
+wire [M+1:0] mx_expanded;
+assign mx_expanded = {1'b1, mx, 1'b0};
+
+assign op_sub = sa_i ^ sb_i;
+assign my_shift_neg_comp  = {M+2{op_sub & y_nzero}} ^ my_shift;
+assign {my_shift_neg_carry_unused, my_shift_neg } = my_shift_neg_comp + {{M+1{1'b0}}, op_sub & y_nzero}; // 9
+assign {mr_carry, mr} = mx_expanded + my_shift_neg;
+
+// rounds to zero: clamps to largest finite number in case of overflow to
+// +/- inf
+logic rz_max;
+assign rz_max = {{E-1{1'b1}}, 1'b0} == ex;
+
+// normalize: 2 bit shifter
+// if addition: division by 2 might be needed
+// if substraction: multiplication by 2 might be needed
+
+logic [M-1:0] mr_norm;// removing hidden 1 and extra lsb
+logic [E-1:0] er_norm;
+/* verilator lint_off UNUSEDSIGNAL */
+logic         er_norm_carry; // overflow will be prevented by rz_max logic
+/* verilator lint_on UNUSEDSIGNAL */
+
+// a little ugly but useing a case to give more flexibility for optimization
+always @(*) begin
+        casez({mr_carry & ~op_sub, mr[M+1]})
+                2'b00: begin // divide by 2
+                        {er_norm_carry, er_norm} = ex - {{E-1{1'b0}},1'b1};
+                        //mr_prenorm = {mr[M:0], 1'b0}; // left shift 1, inject round bit
+                        mr_norm = mr[M-1:0]; // left shift 1, inject round bit
+                end
+                2'b1?: begin // multiply by 2
+                        {er_norm_carry, er_norm} = ex + {{E-1{1'b0}}, ~rz_max};
+                        mr_norm = rz_max ? {M{1'b1}}: mr[M+1:2]; // right shit 1
+                end
+                2'b01: begin // default
+                        er_norm_carry = 1'b0;
+                        er_norm = ex;
+                        mr_norm = mr[M:1]; // removed hidden 1 and sticky
+                end
+        endcase
+end
+
+/* ---------
+ * close path
+ * ---------- */
+
+// 1 bit shift
+wire [M+1:0] my_cp_shifted; // p+1 width, including hidden 1
+wire [M+1:0] mx_cp;
+
+assign my_cp_shifted = exy_eq ? {y_nzero, my, 1'b0} : {1'b0, y_nzero, my}; // div 2, e_x - e_y = 1, e_x - e_y > 1 will be handed by far path
+assign mx_cp = { 1'b1, mx, 1'b0};
+
+// absolute difference between significants
+wire [M+1:0] mxy_cp_abs_diff;
+wire [M+1:0] mxy_cp_diff, myx_cp_diff;
+wire         mxy_cp_diff_carry;
+wire         myx_cp_diff_carry_unused;
+
+assign {mxy_cp_diff_carry, mxy_cp_diff} = mx_cp - my_cp_shifted;
+assign {myx_cp_diff_carry_unused, myx_cp_diff} = my_cp_shifted - mx_cp;
+
+assign mxy_cp_abs_diff = mxy_cp_diff_carry ? myx_cp_diff: // m_y - m_x
+ mxy_cp_diff; // m_x - m_y
+
+// Leading zero count LZC
+localparam int LZC_W = $clog2(M+3);
+localparam int LZC_V_W = $rtoi($pow(2, $clog2(M+2)));
+wire [LZC_W-1:0] zero_cnt;
+wire             zero_cnt_unused;
+wire [LZC_V_W-1:0] lzc_data;
+
+assign lzc_data = { mxy_cp_abs_diff, {LZC_V_W-(M+2){1'b1}}};
+
+lzc #(.W(LZC_V_W)) m_lzc (
+        .data_i(lzc_data),
+        .cnt_o({zero_cnt_unused, zero_cnt})
+);
+
+// variable shift : renormalization
+// using case again for synth
+/* verilator lint_off UNUSEDSIGNAL */
+logic [M+1:0] mz_cp_norm_lite; //partially unused signal [8] and [0] unused
+/* verilator lint_on UNUSEDSIGNAL */
+
+always @(*) begin
+        case(zero_cnt)
+                'd0: mz_cp_norm_lite = mxy_cp_abs_diff; // no cancellation
+                'd1: mz_cp_norm_lite = {mxy_cp_abs_diff[M:0], 1'b0};
+                'd2: mz_cp_norm_lite = {mxy_cp_abs_diff[M-1:0], 2'b0};
+                'd3: mz_cp_norm_lite = {mxy_cp_abs_diff[M-2:0], 3'b0};
+                'd4: mz_cp_norm_lite = {mxy_cp_abs_diff[M-3:0], 4'b0};
+                'd5: mz_cp_norm_lite = {mxy_cp_abs_diff[M-4:0], 5'b0};
+                'd6: mz_cp_norm_lite = {mxy_cp_abs_diff[M-5:0], 6'b0};
+                'd7: mz_cp_norm_lite = {mxy_cp_abs_diff[M-6:0], 7'b0};
+                'd8: mz_cp_norm_lite = {1'b1, 8'b0}; //only 1 left
+                default: mz_cp_norm_lite = {1'b1,{M+1{1'b0}}}; // full cancellation, nothing is left
+        endcase
+end
+
+// normalize exponent
+wire [E-1:0] ex_lzc_cp_diff;
+wire         ez_cp_underflow;
+wire [E-1:0] ez_cp_norm;
+
+assign {ez_cp_underflow, ex_lzc_cp_diff} = ex - {{E-LZC_W{1'b0}}, zero_cnt};
+
+assign ez_cp_norm = {E{~ez_cp_underflow & ~xy_eq}} & ex_lzc_cp_diff;
+
+// denomral round to 0: mantissa correction
+logic [M-1:0] mz_cp_norm;
+logic ex_eq_zero_cnt;
+assign ex_eq_zero_cnt = ~|ex[E-1:LZC_W] & (ex[LZC_W-1:0] == zero_cnt);
+assign mz_cp_norm = {M{~(xy_eq | ex_eq_zero_cnt |ez_cp_underflow) }} & mz_cp_norm_lite[M:1];// critical path through underflow
+
+/* ---------------------------------
+ * select between close and far path
+ * --------------------------------- */
+wire fp_sel;
+assign fp_sel = ~(~|exy_diff[E-1:1] & op_sub); //  exy_diff < 2 && cancellation
+
+// special case
+// - 0 +/- 0, return +0
+// observation: when x is 0, then y is 0 since ex >= ey and we have no
+// subnormals
+wire sc_sel; // special case select
+wire [E-1:0] er_sc;
+wire [M-1:0] mr_sc;
+
+assign sc_sel = ~x_nzero;
+assign er_sc = {E{1'b0}};
+assign mr_sc = {M{1'b0}};
+
+// return
+assign s_o = fp_sel ? sx : (sx ^ mxy_cp_diff_carry) & ~xy_eq;// sign is allways + for -N + N/ N - N, convention to help equality comparison
+assign e_o = sc_sel ? er_sc : fp_sel ? er_norm : ez_cp_norm;
+assign m_o = sc_sel ? mr_sc : fp_sel ? mr_norm: mz_cp_norm;
+
+`ifdef FORMAL
+
+always @(*) begin
+        // xcheck
+        sva_xcheck_i: assert( ~$isunknown({sa_i, ea_i, ma_i, sb_i, eb_i, mb_i}));
+        sva_xcheck_o: assert( ~$isunknown({s_o, e_o, m_o}));
+
+        // assertions
+        // validate swap working, covers 0 assumptions (x == 0 => y == 0)
+        sva_swap_geq_exp: assert(ex >= ey);
+end
+
+`endif
+endmodule

--- a/src/src/bf16_mul.v
+++ b/src/src/bf16_mul.v
@@ -1,0 +1,134 @@
+/* Copyright (c) 2026, Julia Desmazes. All rights reserved.
+
+  This work is licensed under the Creative Commons Attribution-NonCommercial
+  4.0 International License.
+
+  This code is provided "as is" without any express or implied warranties.
+
+
+  Bfloat16 multiplication
+  c = a*b
+
+  a = { s_a, e_a, m_a }
+  b = { s_b, e_b, m_b }
+*/
+module bf16_mul #(
+        localparam int E = 8,
+        localparam int M = 7
+)(
+        input wire sa_i,
+        input wire [E-1:0] ea_i,
+        input wire [M-1:0] ma_i,
+
+        input wire sb_i,
+        input wire [E-1:0] eb_i,
+        input wire [M-1:0] mb_i,
+
+        output wire s_o,
+        output wire [E-1:0] e_o,
+        output wire [M-1:0] m_o
+);
+
+/* exponent addition */
+localparam [E:0] B       = 9'd127;
+localparam [E:0] B_MIN_1 = 9'd126;
+
+wire [E:0] eab; // ea + eb
+wire [E:0] eab_diff, eab_diff_min1;
+wire       eab_diff_carry;
+wire       eab_diff_min1_carry;
+wire       a_nzero, b_nzero;
+wire       ab_zero;
+
+assign eab = ea_i + eb_i;
+assign {eab_diff_carry, eab_diff} = eab - B;
+assign {eab_diff_min1_carry, eab_diff_min1} = eab - B_MIN_1;
+
+// don't need to check mantissa since we don't support subnormal numbers
+assign {a_nzero, b_nzero} = {|ea_i, |eb_i};
+assign ab_zero = ~a_nzero | ~b_nzero;
+
+// detect under/overflow, mul MSB is on critical path, so
+// detecting and correcting for overflow before normalization
+wire eab_diff_overflow, eab_diff_underflow;
+wire eab_diff_min1_overflow, eab_diff_min1_underflow;
+wire eab_diff_min1_clamp_max, eab_diff_clamp_max;
+wire eab_diff_zero, eab_diff_min1_zero;
+
+assign eab_diff_overflow      = eab_diff[E] & ~eab_diff_carry;
+assign eab_diff_min1_overflow = eab_diff_min1[E] & ~eab_diff_min1_carry;
+assign eab_diff_underflow = eab_diff_carry | ab_zero;
+assign eab_diff_min1_underflow = eab_diff_min1_carry | ab_zero;
+
+// test when diff results in zero, before diff correction for better perf
+assign eab_diff_zero = ~|eab_diff[E:0] | eab_diff_underflow;
+assign eab_diff_min1_zero = ~|eab_diff_min1[E:0] | eab_diff_min1_underflow;
+
+// test when exponent has reached max, revent it from reaching inf
+assign eab_diff_min1_clamp_max = &eab_diff_min1[E-1:1];
+assign eab_diff_clamp_max = &eab_diff[E-1:1];
+
+wire [E-1:0] eab_diff_cor, eab_diff_min1_cor;
+// on overflow round toward zero clamps at largest finite floating point number
+// e = 8'FE
+// using consecutive masking logic to save on a mux being mistakenly infered, exploiting the
+// fact overflow and underflow are exclusive
+assign eab_diff_cor = {E{~eab_diff_underflow}}
+                                        & {{{E-1{eab_diff_overflow | eab_diff_clamp_max}} | eab_diff[E-1:1]}, ~(eab_diff_overflow | eab_diff_clamp_max) & eab_diff[0]};
+assign eab_diff_min1_cor = {E{~eab_diff_min1_underflow}}
+                                             & {{{E-1{eab_diff_min1_overflow | eab_diff_min1_clamp_max}} | eab_diff_min1[E-1:1]}, ~(eab_diff_min1_overflow | eab_diff_min1_clamp_max) & eab_diff_min1[0]};
+
+/* significant multiplication */
+localparam int P2 = 2*(M+1); // double the size of the precision p=m+1 (hidden bit)
+
+wire [M:0] ma, mb; // include hidden bit
+wire [P2-1:0] mz; // ma*mb =mz
+
+
+assign {ma, mb} = {{1'b1, ma_i}, {1'b1, mb_i}}; // zero case will be handled by zero masked on output
+
+// can't reuse existing 8 bit booth radix-4 multiplier because it was
+// optimized for signed numbers, these are unsigned.
+// will be using the yosys's abc synthesized radix4 booth multiplier
+// for unsigned
+booth_unsigned_mul #(.W(M+1)) m_booth_radix4_unsugned_mul(
+        .x_i(ma),
+        .y_i(mb),
+        .z_o(mz)
+);
+
+// normalize
+wire [E-1:0] ez_norm;
+wire         z_zero; // underflow
+wire         z_max; // overflow
+wire [M-1:0] mz_norm_lite;
+wire [M-1:0] mz_norm;
+wire         mz_msb;
+
+assign mz_msb  = mz[P2-1];
+assign ez_norm = mz_msb? eab_diff_min1_cor: eab_diff_cor;
+assign z_zero  = mz_msb? eab_diff_min1_zero: eab_diff_zero;
+assign z_max   = mz_msb? eab_diff_min1_overflow: eab_diff_overflow;
+
+assign mz_norm_lite = mz_msb ? mz[P2-2-:M] : mz[P2-3-:M];
+assign mz_norm = mz_norm_lite & {M{~z_zero}} | {M{z_max}};
+
+/* result */
+assign s_o = sa_i ^ sb_i;
+assign e_o = ez_norm;
+assign m_o = mz_norm;
+
+`ifdef FORMAL
+
+always @(*) begin
+        // xcheck
+        sva_xcheck_i: assert( ~$isunknown({sa_i, ea_i, ma_i, sb_i, eb_i, mb_i}));
+        sva_xcheck_o: assert( ~$isunknown({s_o, e_o, m_o}));
+
+        // exponent overflow and underflow are mutually exclusive
+        sva_exponent_overflow_underflow_diff_exclusive: assert( $onehot0({eab_diff_overflow, eab_diff_underflow}));
+        sva_exponent_overflow_underflow_diff_min1_exclusive: assert( $onehot0({eab_diff_min1_overflow, eab_diff_min1_underflow}));
+end
+
+`endif
+endmodule

--- a/src/src/booth_unsigned_mul.v
+++ b/src/src/booth_unsigned_mul.v
@@ -1,0 +1,19 @@
+/*Copyright (c) 2026, Julia Desmazes. All rights reserved.
+
+  This work is licensed under the Creative Commons Attribution-NonCommercial
+  4.0 International License.
+
+  This code is provided "as is" without any express or implied warranties.
+*/
+
+// Placeholder module, actual mul will be inferred by yosys abc
+module booth_unsigned_mul #(
+        parameter W = 8
+)(
+        input wire [W-1:0] x_i,
+        input wire [W-1:0] y_i,
+        output wire [2*W-1:0] z_o
+);
+
+assign z_o = x_i * y_i;
+endmodule

--- a/src/src/bsc.v
+++ b/src/src/bsc.v
@@ -1,0 +1,92 @@
+/*
+ * BSC - Basic Boundary Scan Cell
+ * Used for JTAG boundary scanning
+ *
+ * modules
+ * bsc: configurable wrapped for W wide data
+ * bsc_inner: bsc implementation, single bit wide data
+ *
+ * Julia Desmazes, 25, this code is humman made
+ */
+
+`timescale 1ns / 1ps
+
+module bsc #(
+        parameter W = 1
+        )(
+        input wire tck,
+
+        input wire  [W-1:0] data_i,
+        output wire [W-1:0] data_o,
+
+        input wire  scan_i,
+        output wire scan_o,
+
+        input wire  shift_i,   // Shift DR
+        input wire  capture_i, // Capture DR
+        input wire  update_i,  // Update DR
+        input wire  mode_i
+);
+
+wire [W-1:0] chain;
+wire [W-1:0] scan_next;
+
+genvar i;
+generate
+        for (i=0; i<W; i=i+1) begin: g_bsp_inner
+                if ( i == 0 )
+                        assign chain[i] = scan_i;
+                else
+                        assign chain[i] = scan_next[i-1];
+
+                bsc_inner m_inner(
+                        .tck(tck),
+
+                        .data_i(data_i[i]),
+                        .data_o(data_o[i]),
+
+                        .scan_i(chain[i]),
+                        .scan_o(scan_next[i]),
+
+                        .shift_i(shift_i),
+                        .capture_i(capture_i),
+                        .update_i(update_i),
+                        .mode_i(mode_i)
+                );
+        end
+endgenerate
+
+assign scan_o = scan_next[W-1];
+
+endmodule
+
+module bsc_inner(
+        input wire  tck,
+
+        input wire  data_i,
+        output wire data_o,
+
+        input wire  scan_i,
+        output wire scan_o,
+
+        input wire  shift_i,   // Shift DR
+        input wire  capture_i, // Capture DR
+        input wire  update_i,  // Update DR
+        input wire  mode_i
+);
+wire ff_1_next, ff_2_next;
+reg  ff_1_q, ff_2_q;
+
+assign ff_1_next = shift_i ? scan_i: data_i;
+assign ff_2_next = ff_1_q;
+
+always @(posedge tck)
+        if (capture_i) ff_1_q <= ff_1_next;
+
+always @(posedge tck)
+        if (update_i) ff_2_q <= ff_2_next;
+
+assign scan_o = ff_1_q;
+assign data_o = mode_i ? ff_2_q : data_i;
+
+endmodule

--- a/src/src/ir.v
+++ b/src/src/ir.v
@@ -1,0 +1,40 @@
+/*
+ * IR - Instruction Register
+ * Part of the JRAG TAP
+ *
+ * Julia Desmazes, 2025, human made code
+ */
+
+`timescale 1ns / 1ps
+`default_nettype none
+
+module ir #(
+        parameter          W=2,// IR length
+        parameter [W-1:0] RESET_OPCODE = 2'd0// can be IDCODE of BYPASS according to spec
+    )(
+        input wire  rst_tap,
+
+        input wire  tck_i,
+        input wire  tdi_i,
+        output wire tdo_o,
+
+        input wire  capture_i,
+        input wire  shift_i,
+        input wire  update_i,
+
+        output wire [W-1:0] inst_o
+);
+reg [W-1:0] shift_q;//shift register
+reg [W-1:0] hold_q; //hold register
+
+always @(posedge tck_i)
+        if (capture_i)    shift_q <= hold_q;
+        else if (shift_i) shift_q <= {tdi_i, shift_q[W-1:1]};
+
+always @(posedge tck_i)
+        if (rst_tap) hold_q <= RESET_OPCODE;
+        else if(update_i) hold_q <= shift_q;
+
+assign inst_o = hold_q;
+assign tdo_o = shift_q[0];
+endmodule

--- a/src/src/jtag.v
+++ b/src/src/jtag.v
@@ -1,0 +1,202 @@
+/*
+ * JTAG TAP Controller
+ *
+ * Julia Desmazes, 25, human made code
+ */
+
+`timescale 1ns / 1ps
+`default_nettype none
+
+module jtag #(
+        parameter IR_W = 3,
+        parameter [3:0]  VERSION_NUM = 4'he,
+        parameter [15:0] PART_NUM = 16'hbeef,
+        parameter [10:0] MANIFACTURE_ID = 11'h6b,// <-- do you get the joke ?
+        parameter UREG_ADDR_W = 4, // user register address size
+        parameter UREG_DATA_W = 8, // user register size
+        parameter UREG_W = (UREG_ADDR_W >= UREG_DATA_W)? UREG_ADDR_W: UREG_DATA_W
+        )(
+        input wire  tck_i,
+        input wire  tms_i,
+        input wire  tdi_i,
+        input wire  trst_i, // optional, adding to guaranty FSM is in reset to help reduce power
+        output wire tdo_o,
+
+        // Boundary Scan Chain
+        output wire bsc_shift_o,
+        output wire bsc_capture_o,
+        output wire bsc_update_o,
+        output wire bsc_mode_o,
+
+        input wire bsc_tdo_i,
+
+        // FF Scan Chain
+    output wire sc_en_o,
+    output wire sc_tdi_o,
+    input wire  sc_tdo_i,
+
+        output wire [UREG_ADDR_W-1:0] ureg_addr_o,
+        input wire  [UREG_DATA_W-1:0] ureg_data_i
+);
+/* supported instruction opcodes
+ * some instructions opcodes can be implementation defined, this isn't
+ * the case for the following two instructions :
+ * EXTEST - 0
+ * BYPASS - max (all ones)  */
+localparam [IR_W-1:0] EXTEST         = {IR_W{1'b0}};// 0 - spec defined
+localparam [IR_W-1:0] IDCODE         = {{IR_W-1{1'b0}}, 1'b1}; // 1
+localparam [IR_W-1:0] SAMPLE_PRELOAD = {{IR_W-2{1'b0}}, 2'd2}; // 2
+localparam [IR_W-1:0] USER_REG       = {{IR_W-2{1'b0}}, 2'd3}; // 3
+localparam [IR_W-1:0] SCAN_CHAIN     = 3'd4;                   // 4
+/* verilator lint_off UNUSEDPARAM */
+localparam [IR_W-1:0] BYPASS         = {IR_W{1'b1}};         // max
+/* verilator lint_on UNUSEDPARAM */
+
+/* part identifier, returned on IDCODE */
+localparam [31:0] PART_ID = {VERSION_NUM, PART_NUM, MANIFACTURE_ID, 1'b1};
+/* TAP FSM */
+localparam RESET      = 0;
+localparam IDLE       = 1;
+localparam DR_SELECT  = 2;
+localparam DR_CAPTURE = 3;
+localparam DR_SHIFT   = 4;
+localparam DR_EXIT_1  = 5;
+localparam DR_PAUSE   = 6;
+localparam DR_EXIT_2  = 7;
+localparam DR_UPDATE  = 8;
+localparam IR_SELECT  = 9;
+localparam IR_CAPTURE = 10;
+localparam IR_SHIFT   = 11;
+localparam IR_EXIT_1  = 12;
+localparam IR_PAUSE   = 13;
+localparam IR_EXIT_2  = 14;
+localparam IR_UPDATE  = 15;
+
+(* MARK_DEBUG = "true" *) reg [3:0] fsm_q;
+(* MARK_DEBUG = "true" *) reg  jtag_enabled_q;
+
+(* MARK_DEBUG = "true" *) wire debug_trst, debug_tck, debug_tms;
+assign debug_trst = trst_i;
+assign debug_tck = tck_i;
+assign debug_tms = tms_i;
+
+(* MARK_DEBUG = "true" *) wire fsm_rst;
+assign fsm_rst = trst_i | ~jtag_enabled_q;
+
+/* fsm is reset though the RESET TAP */
+always @(posedge tck_i) begin
+        if (fsm_rst) begin
+                fsm_q <= RESET;
+        end else begin // block isn't going to be power gatted
+                case(fsm_q)
+                        RESET:      fsm_q <= tms_i? RESET: IDLE;
+                        IDLE:       fsm_q <= tms_i? DR_SELECT: IDLE;
+                        DR_SELECT:  fsm_q <= tms_i? IR_SELECT: DR_CAPTURE;
+                        DR_CAPTURE: fsm_q <= tms_i? DR_EXIT_1: DR_SHIFT;
+                        DR_SHIFT:   fsm_q <= tms_i? DR_EXIT_1: DR_SHIFT;
+                        DR_EXIT_1:  fsm_q <= tms_i? DR_UPDATE: DR_PAUSE;
+                        DR_PAUSE:   fsm_q <= tms_i? DR_EXIT_2: DR_PAUSE;
+                        DR_EXIT_2:  fsm_q <= tms_i? DR_UPDATE: DR_SHIFT;
+                        DR_UPDATE:  fsm_q <= tms_i? DR_SELECT: IDLE;
+                        IR_SELECT:  fsm_q <= tms_i? RESET: IR_CAPTURE;
+                        IR_CAPTURE: fsm_q <= tms_i? IR_EXIT_1: IR_SHIFT;
+                        IR_SHIFT:   fsm_q <= tms_i? IR_EXIT_1: IR_SHIFT;
+                        IR_EXIT_1:  fsm_q <= tms_i? IR_UPDATE: IR_PAUSE;
+                        IR_PAUSE:   fsm_q <= tms_i? IR_EXIT_2: IR_PAUSE;
+                        IR_EXIT_2:  fsm_q <= tms_i? IR_UPDATE: IR_SHIFT;
+                        IR_UPDATE:  fsm_q <= tms_i? DR_SELECT: IDLE;
+                endcase
+        end
+end
+
+
+/* IR register */
+(* MARK_DEBUG = "true" *) wire [IR_W-1:0] ir;
+wire ir_tdo;
+ir #(.W(IR_W), .RESET_OPCODE(IDCODE)) m_ir(
+        .rst_tap(trst_i | ~jtag_enabled_q | (fsm_q == RESET)),
+
+        .tck_i(tck_i),
+        .tdi_i(tdi_i),
+        .tdo_o(ir_tdo),
+
+        .capture_i(fsm_q == IR_CAPTURE),
+        .shift_i(fsm_q == IR_SHIFT),
+        .update_i(fsm_q == IR_UPDATE),
+
+        .inst_o(ir)
+);
+
+/* IDCODE */
+reg [31:0] idcode_q;
+always @(posedge tck_i) begin
+        if (fsm_q == DR_CAPTURE)    idcode_q <= PART_ID;
+        else if (fsm_q == DR_SHIFT) idcode_q <= {tdi_i, idcode_q[31:1]};
+end
+
+/* BYPASS */
+reg bypass_q;
+always @(posedge tck_i) begin
+        if (fsm_q == DR_CAPTURE) bypass_q <= 1'b0;
+        else if (fsm_q == DR_SHIFT) bypass_q <= tdi_i;
+end
+
+/* USER REGISTER */
+reg [UREG_ADDR_W-1:0]        ureg_addr_q;
+reg [UREG_W-UREG_ADDR_W-1:0] unused_ureg_addr_q;
+reg [UREG_W-1:0]             ureg_data_q;
+reg [UREG_W-1:0]             ureg_tdi_q;
+
+// addr
+always @(posedge tck_i) begin
+        if (ir == USER_REG) begin
+                if (fsm_q == DR_UPDATE)
+                        { unused_ureg_addr_q , ureg_addr_q } <= ureg_tdi_q;
+                else if (fsm_q == DR_SHIFT)
+                        ureg_tdi_q  <= {tdi_i, ureg_tdi_q[UREG_W-1:1]};
+        end
+end
+// data
+always @(posedge tck_i) begin
+        if (ir == USER_REG) begin
+                if (fsm_q == DR_CAPTURE)
+                        ureg_data_q <= ureg_data_i;
+                else if (fsm_q == DR_SHIFT)
+                        ureg_data_q <= {1'b0, ureg_data_q[UREG_W-1:1]};
+        end
+end
+assign ureg_addr_o = ureg_addr_q;
+
+/* SCAN_CHAIN_CHAIN */
+assign sc_en_o = jtag_enabled_q & (ir == SCAN_CHAIN) & (fsm_q == DR_SHIFT);
+assign sc_tdi_o = tdi_i;
+
+/* JTAG dissabled mask */
+always @(posedge tck_i or posedge trst_i) begin
+  if (trst_i)
+    jtag_enabled_q <= 1'b0;
+  else
+    jtag_enabled_q <= 1'b1;
+end
+
+/* DR */
+wire dr_tdo;
+assign bsc_capture_o = (fsm_q == DR_SHIFT | fsm_q == DR_CAPTURE ) & (ir == EXTEST | ir == SAMPLE_PRELOAD);
+assign bsc_shift_o   = fsm_q == DR_SHIFT   & (ir == EXTEST | ir == SAMPLE_PRELOAD);
+assign bsc_update_o  = fsm_q == DR_UPDATE  & (ir == EXTEST | ir == SAMPLE_PRELOAD);
+assign bsc_mode_o    = jtag_enabled_q & ir == EXTEST;
+
+/* TDO mux */
+assign dr_tdo = (ir == IDCODE) ? idcode_q[0] :
+                                (ir == SAMPLE_PRELOAD | ir == EXTEST) ? bsc_tdo_i:
+                                (ir == USER_REG) ? ureg_data_q[0] :
+                                (ir == SCAN_CHAIN) ? sc_tdo_i:
+                                bypass_q;
+
+reg tdo_q;
+always @(posedge tck_i) begin
+        tdo_q <= (fsm_q == IR_SHIFT)? ir_tdo:
+                 dr_tdo;
+end
+assign tdo_o = tdo_q;
+endmodule

--- a/src/src/lzc.v
+++ b/src/src/lzc.v
@@ -1,0 +1,94 @@
+/* Copyright (c) 2026, Julia Desmazes. All rights reserved.
+
+  This work is licensed under the Creative Commons Attribution-NonCommercial
+  4.0 International License.
+
+  This code is provided "as is" without any express or implied warranties.
+*/
+
+/* Tree Leading Zero Count
+ *
+ * This implementation works with the assumption that the
+ * input data width is a power of 2
+ *
+ * This monstrosity is getting its own tb
+ */
+
+/* First level of the tree */
+module lzc_leaf (
+        input wire [1:0] pair_i,
+        output wire [1:0] cnt_o
+);
+
+assign cnt_o[1] = ~pair_i[1] & ~pair_i[0]; // pair == 00
+assign cnt_o[0] = ~pair_i[1] & pair_i[0]; // pair == 01
+endmodule
+
+/* Inner tree levels
+ *
+ * break "circular logic" dependancy: this logic isn't circular in the synthesis sense
+ * but is circular from the IEEE event model analyses events perspective. Events are
+ * analysed per signal and not per bit.
+ */
+module lzc_inner #(
+        parameter int W = 2
+)(
+
+        input wire [W-1:0] left_i,
+        input wire [W-1:0] right_i,
+/* verilator lint_off UNOPTFLAT */
+        output wire [W:0]  next_o
+/* verilator lint_on UNOPTFLAT */
+);
+wire lmsb, rmsb;
+
+assign lmsb = left_i[W-1];
+assign rmsb = right_i[W-1];
+
+// this is where the magic happens
+assign next_o = ~lmsb ? { 2'b0, left_i[W-2:0] } :
+                                 rmsb ? { 1'b1, {W{1'b0}}}:
+                                                { 2'b01, right_i[W-2:0]};
+endmodule
+
+module lzc #(
+        parameter int W = 4,
+        parameter int I_W = $clog2((W + 1)) // cover W case, need +1 bits
+        )(
+        input wire  [W-1:0]   data_i,
+        output wire [I_W-1:0] cnt_o
+        );
+
+// first level, convert every leaf to there leading zero count
+wire [W-1:0] leaf_lzc;
+genvar i;
+generate
+        for(i = 0; i < W/2 ; i = i+1)begin : g_leaf_lzc
+                lzc_leaf m_leaf_lzc(
+                        .pair_i(data_i[2*i+1:2*i]),
+                        .cnt_o(leaf_lzc[2*i+1:2*i])
+                );
+        end
+endgenerate
+
+wire [W-1:0] lzc_tree[I_W-2:0];
+assign lzc_tree[0] = leaf_lzc;
+
+// inner levels
+genvar j;
+generate
+        for(i=2; i < I_W ; i= i+1)begin: g_inner_lzc_lvl
+                for(j=0; j < $rtoi($pow(2,I_W-i-1)); j = j + 1)begin: g_inner_lzc_span
+                // left/right is a pair of 2*i bits
+                lzc_inner #(.W(i))
+                m_inner_lzc (
+                        .left_i (lzc_tree[i-2][2*i*j+i+:i]),
+                        .right_i(lzc_tree[i-2][2*i*j+:i]),
+                        .next_o (lzc_tree[i-1][(i+1)*j+:i+1])
+                );
+                end
+        end
+endgenerate
+
+assign cnt_o = lzc_tree[I_W-2][I_W-1:0];
+endmodule

--- a/src/src/mac.v
+++ b/src/src/mac.v
@@ -1,0 +1,138 @@
+/*
+ * Multiply accumulate systolic array top of size NxN
+ *
+ * Julia Desmazes, 2025, this code is human made
+ */
+
+`timescale 1ns / 1ps
+
+module mac #(
+        parameter IO_W = 8,
+        parameter W = 8, // data and weight width
+        parameter N = 2, // matrix dimention
+        parameter UREG_ADDR = 4
+)(
+        input wire clk,
+        input wire rst_n,
+        input wire ena,
+
+        input wire            data_v_i,
+        input wire [1:0]      data_mode_i,
+        input wire [IO_W-1:0] data_i,
+
+        /* DFT: JTAG USER_REG */
+        input wire  [UREG_ADDR-1:0] jtag_ureg_addr_i,
+        output wire [W-1:0]         jtag_ureg_data_o,
+
+        output wire            result_v_o,
+        output wire [IO_W-1:0] result_o
+);
+localparam NN = N*N;
+genvar x,y;
+
+/* FSM */
+logic [NN-1:0] wr_weight_v_flat; // limited support for multidimentional array in the simulator
+logic          wr_weight_v[N-1:0][N-1:0];
+logic [N-1:0]  wr_data_v;
+reg   [N*W-1:0] data_input_q;
+logic          mac_step;
+logic [2:0]   rd_res_seq_v;
+
+mac_fsm #(.IO_W(IO_W), .W(W)) m_fsm(
+        .clk(clk),
+        .rst_n(rst_n),
+        .ena(ena),
+
+        .data_v_i(data_v_i),
+        .data_mode_i(data_mode_i),
+
+        .wr_weight_v_o(wr_weight_v_flat),
+        .wr_data_v_o(wr_data_v),
+
+        .mac_step_o(mac_step),
+
+        .rd_res_seq_v_o(rd_res_seq_v)
+);
+generate
+        for(x=0; x<N; x=x+1) begin: g_wr_weight_v_x
+                for(y=0; y<N; y=y+1) begin: g_wr_weight_v_y
+                        assign wr_weight_v[x][y] = wr_weight_v_flat[y*N+x];
+                end
+        end
+endgenerate
+
+/* Steamin data */
+mac_streamin #(.IN_W(IO_W), .W(W)) m_mac_data_streamin_2x2(
+        .clk(clk),
+        .data_i(data_i),
+        .data_wr_v_i(wr_data_v),
+        .data_o(data_input_q)
+);
+
+/* Systolic array */
+
+logic [W-1:0] data_unit[N-1:0][N-1:0];
+logic [W-1:0] data_flow_right[N-1:0][N-1:0];
+logic [W-1:0] data_top_unit[N-1:0][N-1:0];
+logic [W-1:0] res_unit[N-1:0][N-1:0];
+
+logic [W-1:0] jtag_ureg_data[NN-1:0];
+
+generate
+        for(y=0; y<N; y=y+1) begin: g_data_unit
+                assign data_unit[0][y] = data_input_q[y*W+:W];
+                for(x=1; x<N; x=x+1) begin: g_data_unit_flow
+                        assign data_unit[x][y] = data_flow_right[x-1][y];
+                end
+        end
+
+        /* data top */
+        for(x=0; x < N; x=x+1) begin: g_data_top_x
+                assign data_top_unit[x][0] = {W{1'b0}};
+                for(y=1; y < N; y=y+1) begin: g_data_top_y
+                        assign data_top_unit[x][y] = res_unit[x][y-1];
+                end
+        end
+
+        for(x=0; x < N; x=x+1) begin: g_unit_x
+                for(y=0; y < N; y=y+1) begin: g_unit_y
+                        mac_unit #(.W(W)) m_unit(
+                                .clk(clk),
+
+                                .step_i(mac_step),
+
+                                .data_i(data_unit[x][y]),
+                                .data_top_i(data_top_unit[x][y]),
+
+                                .wr_weight_v_i(wr_weight_v[x][y]),
+                                .weight_i(data_i),
+
+                                .jtag_ureg_addr_i(jtag_ureg_addr_i[1:0]),
+                                .jtag_ureg_data_o(jtag_ureg_data[y*N+x]),
+
+                                .data_o(data_flow_right[x][y]),
+                                .res_o(res_unit[x][y])
+                        );
+                end
+        end
+endgenerate
+wire [W-1:0] debug_res0_0, debug_res1_0, debug_res0_1, debug_res1_1;
+assign debug_res0_0 = res_unit[0][0];
+assign debug_res1_0 = res_unit[1][0];
+assign debug_res0_1 = res_unit[0][N-1];
+assign debug_res1_1 = res_unit[1][N-1];
+
+/* result streamout */
+mac_streamout #(.W(W), .OUT_W(IO_W)) m_mac_result_streamout_2x2(
+        .clk(clk),
+        .rst_n(rst_n),
+        .res_rd_seq_v_i(rd_res_seq_v),
+        .res_data_i({res_unit[1][N-1], res_unit[0][N-1]}),
+        .valid_o(result_v_o),
+        .data_o(result_o)
+);
+
+// JTAG user register access
+assign jtag_ureg_data_o = jtag_ureg_data[jtag_ureg_addr_i[3:2]];
+
+endmodule

--- a/src/src/mac_fsm.v
+++ b/src/src/mac_fsm.v
@@ -1,0 +1,133 @@
+/*
+ * Multiply accumulate systolic array top of size NxN FSM
+ *
+ * Orchastrates the MAC behavior
+ *
+ * This code will be simplified by synth, maximizing readability
+ *
+ * Julia Desmazes, 2026, human made code
+ */
+
+`timescale 1ns / 1ps
+
+module mac_fsm #(
+        parameter IO_W = 8,
+        parameter W = 16,
+        localparam N = 2,
+        localparam NN = N*N,
+        localparam OSEQ_W = 3
+)(
+        input wire clk,
+        input wire rst_n,
+        input wire ena,
+
+        input wire       data_v_i,
+        input wire [1:0] data_mode_i,
+
+        output wire [NN-1:0] wr_weight_v_o,
+        output wire [N-1:0]  wr_data_v_o,
+
+        output wire mac_step_o, // cam step through
+
+        output wire [OSEQ_W-1:0] rd_res_seq_v_o // streamout res sequence
+
+);
+/* data modes */
+localparam MODE_DATA   = 2'd0;
+localparam MODE_WEIGHT = 2'd1;
+localparam MODE_RST    = 2'd2;
+/* verilator lint_off UNUSEDPARAM */
+localparam MODE_ASM    = 2'd3;
+/* verilator lint_on UNUSEDPARAM */
+
+localparam MAX_UNIT_IDX = NN;
+localparam UNIT_IDX_W   = $clog2(MAX_UNIT_IDX);
+localparam DATA_IDX_W   = $clog2(MAX_UNIT_IDX*(W/IO_W));
+
+/* rst all write addr */
+wire rst_addr;
+assign rst_addr = data_v_i & (data_mode_i == MODE_RST);
+
+/* weight write logic */
+wire                 wr_weight_v;
+reg [DATA_IDX_W-1:0] wr_weight_idx_q;
+reg                  wr_weight_idx_carry_unused;
+reg [NN-1:0]         wr_weight_unit_v;
+
+assign wr_weight_v = data_v_i & (data_mode_i == MODE_WEIGHT);
+always @(posedge clk)
+        if (~rst_n |  rst_addr ) wr_weight_idx_q <= {DATA_IDX_W{1'b0}};
+        else if (wr_weight_v) {wr_weight_idx_carry_unused, wr_weight_idx_q} <= wr_weight_idx_q + {{DATA_IDX_W-1{1'b0}}, 1'b1};
+
+always @(*) begin
+        case(wr_weight_idx_q[DATA_IDX_W-1-:UNIT_IDX_W])
+                2'd0: wr_weight_unit_v = 4'b0001;
+                2'd1: wr_weight_unit_v = 4'b0010;
+                2'd2: wr_weight_unit_v = 4'b0100;
+                2'd3: wr_weight_unit_v = 4'b1000;
+        endcase
+end
+
+assign wr_weight_v_o = {NN{wr_weight_v}} & wr_weight_unit_v;
+
+/* data write logic
+ *
+ * Control storage located in the streamin module.
+ * Capture incoming data over 8 bit wide bus and feed it to the
+ * systolic array. */
+wire                  wr_data_v;
+reg  [DATA_IDX_W-1:0] wr_data_idx_q;
+reg                   wr_data_idx_carry_unused;
+reg  [N-1:0]          wr_data_row_v;
+
+assign wr_data_v = data_v_i & (data_mode_i == MODE_DATA);
+
+always @(posedge clk)
+        if (~rst_n | rst_addr ) wr_data_idx_q <= {DATA_IDX_W{1'b0}};
+        else if (wr_data_v) {wr_data_idx_carry_unused, wr_data_idx_q} <= wr_data_idx_q + {{DATA_IDX_W-1{1'b0}}, 1'b1};
+
+always @(*) begin
+        case(wr_data_idx_q[DATA_IDX_W-1-:UNIT_IDX_W])
+                2'd0: wr_data_row_v = 2'b01;
+                2'd1: wr_data_row_v = 2'b10;
+                2'd2: wr_data_row_v = 2'b01;
+                2'd3: wr_data_row_v = 2'b10;
+        endcase
+end
+
+assign wr_data_v_o = {N{wr_data_v}} & wr_data_row_v;
+
+/* N dimention dependant logic
+ *
+ * MAC steps, depend on data arrival sequence */
+reg last_step_q;
+reg mac_step_q;
+reg [OSEQ_W-1:0] rd_res_seq_d1_q; // d1: delayed by 1 cycle
+reg [OSEQ_W-1:0] rd_res_seq_q;
+reg en_q;
+always @(posedge clk)
+        en_q <= ena;
+
+always @(posedge clk)
+        last_step_q <= wr_data_v & en_q & (wr_data_idx_q == {2'd3, 1'b1});
+
+always @(posedge clk) begin
+        if (en_q & (wr_data_v | last_step_q))  begin
+                case(wr_data_idx_q)
+                        {2'd0,1'b1}: {rd_res_seq_d1_q, mac_step_q} <= {3'b000, 1'b1};// 0,0
+                        {2'd2,1'b1}: {rd_res_seq_d1_q, mac_step_q} <= {3'b001, 1'b1};//1,0 + 0,1
+                        {2'd3,1'b1}: {rd_res_seq_d1_q, mac_step_q} <= {3'b010, 1'b1};//1,1 + last_step next cycle
+                        default:     {rd_res_seq_d1_q, mac_step_q} <= {{last_step_q, 2'b00}, last_step_q};
+                endcase
+        end else {rd_res_seq_d1_q, mac_step_q} <= {3'b000, 1'b0};
+end
+assign mac_step_o = mac_step_q;
+
+/* Streamout sequencer
+ * Data production depends on mac step though which in
+ * turn depends on data arrival */
+always @(posedge clk)
+        rd_res_seq_q <= rd_res_seq_d1_q;
+
+assign rd_res_seq_v_o = rd_res_seq_q;
+endmodule

--- a/src/src/mac_streamin.v
+++ b/src/src/mac_streamin.v
@@ -1,0 +1,35 @@
+/* MAC data streamin
+ * maps GPIO io onto systollic array input
+ */
+module mac_streamin #(
+        parameter IN_W = 8,
+        parameter W = 16,
+        localparam N = 2
+)(
+        input wire clk,
+
+        // GPIO interface
+        input wire [IN_W-1:0] data_i,
+
+        // FSM interface
+        input wire [N-1:0]    data_wr_v_i, // onehot0
+
+        // to systolic array
+        output wire [N*W-1:0]  data_o
+);
+reg [N*W-1:0] buf_q;
+
+// would rather have a recursive macro engine to generate this code
+always @(posedge clk) begin
+        if (data_wr_v_i[0])
+                buf_q[W-1:0] <= {data_i, buf_q[W-1:IN_W]};
+        if (data_wr_v_i[1])
+                buf_q[2*W-1:W] <= {data_i, buf_q[2*W-1:IN_W+W]};
+end
+
+assign data_o = buf_q;
+
+`ifdef FORMAL
+        sva_data_wr_v_onehot0: assert($onehot0(data_wr_v_i));
+`endif
+endmodule

--- a/src/src/mac_streamout.v
+++ b/src/src/mac_streamout.v
@@ -1,0 +1,89 @@
+/* MAC data streamout
+ * Used to guaranty data is streamed to MCU
+ * gappless, this helps save on MCU <-> ASIC
+ * handshaking logic and an extra pin.
+ *
+ * This does come at the cost of some extra
+ * result latency and logic.
+ */
+module mac_streamout #(
+        parameter W = 16,
+        parameter OUT_W = 8,
+        localparam N = 2 // currently designed for a 2x2 array
+)(
+        input wire clk,
+        input wire rst_n,
+
+        // result from systolic array
+        input wire [2:0]       res_rd_seq_v_i,
+        input wire [N*W-1:0]   res_data_i,
+
+        // output IO interface
+        output wire             valid_o,
+        output wire [OUT_W-1:0] data_o
+
+);
+localparam NN = N*N;
+reg [W-1:0] gather_q[NN];
+
+always @(posedge clk) begin
+        if(res_rd_seq_v_i[0])
+                gather_q[0] <= res_data_i[W-1:0];
+        if (res_rd_seq_v_i[1])
+                {gather_q[1], gather_q[2]} <= res_data_i;
+        if (res_rd_seq_v_i[2])
+                gather_q[3] <= res_data_i[N*W-1:W];
+end
+
+// streamout result
+localparam MAX_IDX = ((NN)*(W/OUT_W));
+localparam IDX_W   = $clog2(MAX_IDX+1);
+/*verilator lint_off WIDTHTRUNC */
+// WIDTHTRUNC since MAX_IDX is assumed to be singed, and
+// we are dropping the sign bit in RST_IDX
+localparam [IDX_W-1:0] RST_IDX = MAX_IDX;
+/*verilator lint_on WIDTHTRUNC */
+
+reg [NN*W-1:0]   stream_q;
+wire             mv_gather_to_stream_next;
+reg              mv_gather_to_stream_q;
+reg  [IDX_W-1:0] stream_idx_q;
+wire [IDX_W-1:0] stream_idx_next;
+wire             stream_idx_underflow;
+wire [IDX_W-1:0] stream_idx_sub1;
+
+assign mv_gather_to_stream_next = res_rd_seq_v_i[2];
+always @(posedge clk)
+        mv_gather_to_stream_q <= mv_gather_to_stream_next;
+
+assign {stream_idx_underflow, stream_idx_sub1} = stream_idx_q - {{IDX_W-1{1'b0}},1'd1};
+assign stream_idx_next = stream_idx_underflow ? {IDX_W{1'd0}} : stream_idx_sub1;
+always @(posedge clk) begin
+        if(~rst_n) begin
+                stream_idx_q <= {IDX_W{1'b0}};
+        end else if (mv_gather_to_stream_q) begin
+                stream_q <= {gather_q[3], gather_q[2], gather_q[1], gather_q[0]};
+                stream_idx_q <= RST_IDX;
+        end else begin
+                stream_q <= {{OUT_W{1'bX}}, stream_q[NN*W-1:OUT_W]};
+                stream_idx_q <= stream_idx_next;
+        end
+end
+
+// TODO: add option to reduce output switching freq / 2 ?
+
+// add extra ff layer to help improve increase positive
+// slack on output valid path, need as much as we can if we
+// want to push output GPIO Fmax
+reg out_valid_q;
+always @(posedge clk)
+        out_valid_q <= mv_gather_to_stream_next | mv_gather_to_stream_q | |stream_idx_next; // valid is asserted a cycle before data start being sent
+
+// output
+assign valid_o = out_valid_q;
+assign data_o  = stream_q[OUT_W-1:0];
+
+`ifdef FORMAL
+        sva_idx_onehot0: assert($onehot0(res_rd_seq_v_i));
+`endif
+endmodule

--- a/src/src/mac_unit.v
+++ b/src/src/mac_unit.v
@@ -1,0 +1,105 @@
+/*
+ * Multiply accumulate systolic array unit
+ *
+ * Julia Desmazes, 2025, this code is human made
+ */
+
+`timescale 1ns / 1ps
+`default_nettype none
+
+module mac_unit #(
+        parameter W = 8,
+        parameter IO_W = 8 // weight use IO_W for input and are shifted in
+        )(
+        input wire clk,
+
+        input wire           step_i,
+
+        input wire [W-1:0]   data_i, //right side input data
+        input wire [W-1:0]   data_top_i, // top input data
+
+        input wire            wr_weight_v_i,
+        input wire [IO_W-1:0] weight_i,
+
+        input wire  [1:0]    jtag_ureg_addr_i,
+        output logic [W-1:0] jtag_ureg_data_o,
+
+        output wire [W-1:0]  data_o, // left side output data, will become the right side input data of the next unit leftwards
+        output wire [W-1:0]  res_o // result, become the top input data for the next unit bellow
+);
+reg  [W-1:0] data_q, add_q;
+reg  [W-1:0] weight_q;
+wire [W-1:0] mul;
+
+always @(posedge clk)
+        if (step_i) data_q <= data_i;
+
+always @(posedge clk)
+        if (step_i) add_q <= data_top_i; // critical path end
+
+always @(posedge clk)
+        if (wr_weight_v_i) weight_q <= {weight_i, weight_q[W-1:IO_W]};
+
+`ifdef COCOTB
+/* Replacing floating point model with unsigned integer math
+ * for cocotb since we don't have a good golden model
+ * in python for bf16, bf16 implementations used a clamped down
+ * version of f32 which would result in the accumulation of
+ * the different precision rounding error though the network.
+ * Additionally, float math has already been thoughly verified,
+ * this testbench is focused on checking the array's behavior
+ * and this is indifrent to the underlying base type as long as
+ * the data width is identical. */
+wire [W-1:0] mul_raw_carry, mul_raw;
+assign {mul_raw_carry, mul_raw} = weight_q * data_q;
+// clamping
+assign mul = |mul_raw_carry ? {W{1'b1}} : mul_raw;
+
+wire add_raw_carry;
+wire [W-1:0] add_raw;
+assign {add_raw_carry, add_raw} = mul + add_q;
+assign res_o = add_raw_carry ? {W{1'b1}}: add_raw;
+`else
+// bfloat16 multiplication
+bf16_mul m_mul(
+        .sa_i(weight_q[15]),
+        .ea_i(weight_q[14:7]),
+        .ma_i(weight_q[6:0]),
+
+        .sb_i(data_q[15]),
+        .eb_i(data_q[14:7]),
+        .mb_i(data_q[6:0]),
+
+        .s_o(mul[15]),
+        .e_o(mul[14:7]),
+        .m_o(mul[6:0])
+);
+
+// bfloat16 addition
+bf16_add m_add(
+        .sa_i(mul[15]),
+        .ea_i(mul[14:7]),
+        .ma_i(mul[6:0]),
+
+        .sb_i(add_q[15]),
+        .eb_i(add_q[14:7]),
+        .mb_i(add_q[6:0]),
+
+        .s_o(res_o[15]),
+        .e_o(res_o[14:7]),
+        .m_o(res_o[6:0])
+);
+`endif
+
+assign data_o = data_q;
+
+// jtag user register interface, expected to be used when mac clock is stalled
+always @(*) begin
+        case(jtag_ureg_addr_i)
+                2'b00: jtag_ureg_data_o = weight_q;
+                2'b01: jtag_ureg_data_o = data_q;
+                2'b10: jtag_ureg_data_o = add_q;
+                2'b11: jtag_ureg_data_o = mul;
+        endcase
+end
+endmodule

--- a/src/src/tt_project.v
+++ b/src/src/tt_project.v
@@ -1,13 +1,8 @@
-/*
- * Minimal Tiny Tapeout Echo Project
- *
- * This design simply echoes the input byte (ui_in) to the output byte (uo_out).
- */
-
+`timescale 1ns / 1ps
 `default_nettype none
 
-module tt_um_minimal_echo (
-    input  wire [7:0] ui_in,    // Dedicated inputs
+module tt_um_essen(
+        input  wire [7:0] ui_in,    // Dedicated inputs
     output wire [7:0] uo_out,   // Dedicated outputs
     input  wire [7:0] uio_in,   // IOs: Input path
     output wire [7:0] uio_out,  // IOs: Output path
@@ -17,12 +12,191 @@ module tt_um_minimal_echo (
     input  wire       rst_n     // reset_n - low to reset
 );
 
-    // Assign inputs directly to outputs
-    assign uo_out  = ui_in ^ uio_in;
-    // assign uio_out = ! uio_in;
+localparam BSC_CHAIN_W = 6; // bsc scan chain length
+localparam UREG_DATA_W = 16;
+localparam UREG_ADDR_W = 4;
 
-    // Set UIO to output and show b'10101100
-    assign uio_out = 8'b10101100;
-    assign uio_oe  = 8'b11111111;
+localparam IO_W = 8; // IO data interface width
+localparam W    = 16;// base type, using bfloat16
+
+
+/* IO direction, 0: input, 1: output */
+assign uio_oe = 8'b1100_0000;
+
+/* unused IO */
+wire [1:0] unused_input;
+assign     unused_input = uio_in[7:6];
+assign     uio_out[5:0] = 6'b0;
+
+/* I/O interface, marked for boundary scan insertion */
+(* MARK_BSC = "in"  *) wire            data_v_bsc;
+(* MARK_BSC = "in"  *) wire [1:0]      data_mode_bsc;
+(* MARK_BSC = "in"  *) wire [IO_W-1:0] data_bsc;
+(* MARK_BSC = "out" *) wire            result_v_bsc;
+(* MARK_BSC = "out" *) wire [IO_W-1:0] result_bsc;
+
+wire [BSC_CHAIN_W-1:0] bsc_chain;
+wire bsc_tdo;
+wire bsc_shift;
+wire bsc_capture;
+wire bsc_update;
+(* KEEP = "true", dont_touch = "true" *) wire bsc_mode;
+
+wire            data_v;
+wire [1:0]      data_mode;
+wire [IO_W-1:0] data;
+wire            result_v;
+wire [IO_W-1:0] result;
+
+assign data_v_bsc    = uio_in[1];
+assign data_mode_bsc = uio_in[3:2];
+assign data_bsc      = {uio_in[0], ui_in[7:1]};
+assign uio_out[7]    = result_v_bsc;
+assign uo_out        = result_bsc;
+
+wire tck;
+wire tdi;
+wire tms;
+wire tdo;
+wire trst;
+
+assign bsc_chain[0] = tdi;
+assign bsc_tdo = bsc_chain[BSC_CHAIN_W-1];
+
+bsc #(.W(1)) m_bsc_data_v_in(
+        .tck(tck),
+        .data_i(data_v_bsc), .data_o(data_v),
+        .scan_i(bsc_chain[0]), .scan_o(bsc_chain[1]),
+        .shift_i(bsc_shift), .capture_i(bsc_capture), .update_i(bsc_update), .mode_i(bsc_mode)
+        );
+
+bsc #(.W(2)) m_bsc_data_mode_in(
+        .tck(tck),
+        .data_i(data_mode_bsc), .data_o(data_mode),
+        .scan_i(bsc_chain[1]), .scan_o(bsc_chain[2]),
+        .shift_i(bsc_shift), .capture_i(bsc_capture), .update_i(bsc_update), .mode_i(bsc_mode)
+        );
+
+bsc #(.W(IO_W)) m_bsc_data_in(
+        .tck(tck),
+        .data_i(data_bsc), .data_o(data),
+        .scan_i(bsc_chain[2]), .scan_o(bsc_chain[3]),
+        .shift_i(bsc_shift), .capture_i(bsc_capture), .update_i(bsc_update), .mode_i(bsc_mode)
+        );
+
+bsc #(.W(1)) m_bsc_result_v_out(
+        .tck(tck),
+        .data_i(result_v), .data_o(result_v_bsc),
+        .scan_i(bsc_chain[3]), .scan_o(bsc_chain[4]),
+        .shift_i(bsc_shift), .capture_i(bsc_capture), .update_i(bsc_update), .mode_i(bsc_mode)
+        );
+
+bsc #(.W(IO_W)) m_bsc_result_out(
+        .tck(tck),
+        .data_i(result), .data_o(result_bsc),
+        .scan_i(bsc_chain[4]), .scan_o(bsc_chain[5]),
+        .shift_i(bsc_shift), .capture_i(bsc_capture), .update_i(bsc_update), .mode_i(bsc_mode)
+        );
+
+
+/* DFT interface */
+assign tck        = ui_in[0]; // clk's can only be driven from the ui_in pins
+assign tdi        = uio_in[4];
+assign tms        = uio_in[5];
+assign trst       = ~rst_n; // there is no power gating, stall the design if not enabled
+assign uio_out[6] = tdo;
+
+
+// JTAG
+wire [UREG_ADDR_W-1:0] ureg_addr;
+wire [UREG_DATA_W-1:0] ureg_data;
+
+// SCANCHAIN
+// connected to the scan chain during implementation
+/* verilator lint_off UNUSEDSIGNAL */
+/* verilator lint_off UNDRIVEN */
+wire dft_sc_en;
+wire dft_sc_tdi;
+wire dft_sc_tdo;
+wire jtag_dft_sc_en;
+wire jtag_dft_sc_tdi;
+wire jtag_dft_sc_tdo;
+/* verilator lint_on UNUSEDSIGNAL */
+/* verilator lint_on UNDRIVEN */
+
+`ifdef SCL_sg13g2_stdcell
+// openroad dft scan chain insertion matches component port, not internal nets
+(* keep *) sg13g2_buf_1 m_dft_sc_en_buf (
+        .A(jtag_dft_sc_en),
+        .X(dft_sc_en)
+);
+
+(* keep *) sg13g2_buf_1 m_dft_sc_tdi_buf (
+        .A(jtag_dft_sc_tdi),
+        .X(dft_sc_tdi)
+);
+
+assign dft_sc_tdo = 1'bX;// output of the scan chain, not really X
+(* keep *) sg13g2_buf_1 m_dft_sc_tdo_buf (
+        .A(dft_sc_tdo),
+        .X(jtag_dft_sc_tdo)
+);
+`elsif COCOTB
+`ifndef GL_SIM
+// not gate level simulation
+localparam MOCK_SC_W = 100;
+reg [MOCK_SC_W-1:0] mock_scan_chain_q;
+always @(posedge clk) begin
+        if (jtag_dft_sc_en)
+                mock_scan_chain_q <= {mock_scan_chain_q[MOCK_SC_W-2:0], jtag_dft_sc_tdi};
+end
+assign jtag_dft_sc_tdo = mock_scan_chain_q[MOCK_SC_W-1];
+`endif // GL_SIM
+`endif // SCL_sg13g2_stdcell, COCOTB
+
+jtag #(.IR_W(3),
+        .VERSION_NUM(4'h2),// <- v2 second tapeout
+        .PART_NUM(16'hbeef),
+        .MANIFACTURE_ID(11'h6b),// <-- do you get the joke ?
+        .UREG_ADDR_W(UREG_ADDR_W),
+        .UREG_DATA_W(UREG_DATA_W)
+        ) m_jtag_tap (
+        .tck_i(tck),
+        .tms_i(tms),
+        .tdi_i(tdi),
+        .trst_i(trst),
+        .tdo_o(tdo),
+
+        .bsc_shift_o(bsc_shift),
+        .bsc_capture_o(bsc_capture),
+        .bsc_update_o(bsc_update),
+        .bsc_mode_o(bsc_mode),
+
+        .bsc_tdo_i(bsc_tdo),
+
+        .sc_tdi_o(jtag_dft_sc_tdi),
+        .sc_en_o (jtag_dft_sc_en),
+        .sc_tdo_i(jtag_dft_sc_tdo),
+
+        .ureg_addr_o(ureg_addr),
+        .ureg_data_i(ureg_data)
+);
+
+// MAC design
+mac #(.W(W), .IO_W(IO_W), .N(2)) m_2x2_systolic_mac(
+        .clk(clk),
+        .rst_n(rst_n),
+        .ena(ena),
+
+        .data_v_i(data_v),
+        .data_mode_i(data_mode),
+        .data_i(data),
+
+        .jtag_ureg_addr_i(ureg_addr),
+        .jtag_ureg_data_o(ureg_data),
+
+        .result_v_o(result_v),
+        .result_o(result)
+);
 
 endmodule

--- a/src/src/tt_wrapper.v
+++ b/src/src/tt_wrapper.v
@@ -48,7 +48,7 @@ module tt_m3_wrapper (
 
     // --- Tiny Tapeout Module Instantiation ---
     // Note: Change 'tt_um_minimal_echo' to your actual TT module name
-    tt_um_minimal_echo tt_inst (
+    tt_um_essen tt_inst (
         .ui_in  (ui_in),
         .uo_out (uo_out),
         .uio_in (uio_in),

--- a/tang_nano_4k_tt_uart.gprj
+++ b/tang_nano_4k_tt_uart.gprj
@@ -9,6 +9,18 @@
         <File path="src/top.v" type="file.verilog" enable="1"/>
         <File path="src/tt_project.v" type="file.verilog" enable="1"/>
         <File path="src/tt_wrapper.v" type="file.verilog" enable="1"/>
+        <File path="src/bf16_add.v" type="file.verilog" enable="1"/>
+        <File path="src/bf16_mul.v" type="file.verilog" enable="1"/>
+        <File path="src/booth_unsigned_mul.v" type="file.verilog" enable="1"/>
+        <File path="src/bsc.v" type="file.verilog" enable="1"/>
+        <File path="src/ir.v" type="file.verilog" enable="1"/>
+        <File path="src/jtag.v" type="file.verilog" enable="1"/>
+        <File path="src/lzc.v" type="file.verilog" enable="1"/>
+        <File path="src/mac.v" type="file.verilog" enable="1"/>
+        <File path="src/mac_fsm.v" type="file.verilog" enable="1"/>
+        <File path="src/mac_streamin.v" type="file.verilog" enable="1"/>
+        <File path="src/mac_streamout.v" type="file.verilog" enable="1"/>
+        <File path="src/mac_unit.v" type="file.verilog" enable="1"/>
         <File path="src/top.cst" type="file.cst" enable="1"/>
         <File path="src/m3.ld" type="file.other" enable="1"/>
         <File path="src/m3_regs.h" type="file.other" enable="1"/>

--- a/verify_3647.py
+++ b/verify_3647.py
@@ -1,0 +1,55 @@
+import subprocess
+import time
+import os
+import signal
+import sys
+from playwright.sync_api import sync_playwright, expect
+
+def run_verify():
+    # Kill any existing server on port 8000
+    subprocess.run(["fuser", "-k", "8000/tcp"], stderr=subprocess.DEVNULL)
+
+    server_process = subprocess.Popen(
+        ["python3", "-m", "http.server", "8000", "--directory", "web"],
+        stdout=sys.stdout,
+        stderr=sys.stderr
+    )
+    time.sleep(2)  # Wait for server to start
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            context = browser.new_context()
+            page = context.new_page()
+
+            print("Navigating to http://localhost:8000")
+            page.goto("http://localhost:8000")
+
+            # Verify that tt3647 is selected by default
+            expect(page.locator("#wasmEngineSelect")).to_have_value("tt3647")
+            print("Verified tt3647 is default engine.")
+
+            # Wait for WASM to be ready
+            page.wait_for_selector("#useFullWasm", state="attached")
+            if not page.is_checked("#useFullWasm"):
+                page.check("#useFullWasm")
+
+            # Perform a transaction to see if it works
+            page.fill("#ui_in_hex", "01")
+            page.press("#ui_in_hex", "Enter")
+            page.click("#sendReceive")
+
+            # Wait for console to show "Received (Emulated WASM)"
+            expect(page.locator("#console")).to_contain_text("Received (Emulated WASM)", timeout=10000)
+            print("Verified tt3647 simulation is running.")
+
+            browser.close()
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        if 'page' in locals():
+            page.screenshot(path="verify_3647_failure.png")
+    finally:
+        os.kill(server_process.pid, signal.SIGTERM)
+
+if __name__ == "__main__":
+    run_verify()

--- a/web/app.js
+++ b/web/app.js
@@ -4,7 +4,7 @@
     const wasmParam = urlParams.get('wasm');
 
     // Security check: validate wasmParam
-    let wasmEngine = 'default';
+    let wasmEngine = 'tt3647';
     if (wasmParam && /^tt\d+$/.test(wasmParam)) {
         wasmEngine = wasmParam;
     }


### PR DESCRIPTION
Integrated Project 3647 (tt_um_essen), a 2x2 Systolic Array, into the Tang Nano 4K TT UART framework. This involved adding the full Verilog source tree for the project, updating the top-level FPGA wrappers, and configuring the web tester to use tt3647 as the default simulation module. verified that simulation and UI controls work correctly with the new project.

Fixes #145

---
*PR created automatically by Jules for task [10453500285278005329](https://jules.google.com/task/10453500285278005329) started by @chatelao*