### PR TITLE
Reorder Web Tester Panels: Markdown above Timing Diagram

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -112,6 +112,23 @@
             </div>
         </div>
 
+        <div class="panel markdown-testset-panel">
+            <h2>Markdown Test Cases</h2>
+            <div class="testset-actions">
+                <input type="text" id="mdUrl" placeholder="https://github.com/chatelao/ttihp-fp8-mul/blob/ihp-sg13cmos5l/TEST_CASES.md" class="md-url-input">
+                <button id="fetchMd">Fetch</button>
+            </div>
+            <div class="testset-actions">
+                <select id="mdTableSelect">
+                    <option value="">No tables loaded...</option>
+                </select>
+                <button id="runMdTable" disabled>Run Table</button>
+            </div>
+            <div id="mdTableInfo" class="testset-info">
+                Enter a Markdown URL and click Fetch.
+            </div>
+        </div>
+
         <div class="panel diagram-panel">
             <h2>Timing Diagram</h2>
             <div class="diagram-controls">
@@ -234,23 +251,6 @@
             </div>
             <div id="testsetInfo" class="testset-info">
                 No testset loaded.
-            </div>
-        </div>
-
-        <div class="panel markdown-testset-panel">
-            <h2>Markdown Test Cases</h2>
-            <div class="testset-actions">
-                <input type="text" id="mdUrl" placeholder="https://github.com/chatelao/ttihp-fp8-mul/blob/ihp-sg13cmos5l/TEST_CASES.md" class="md-url-input">
-                <button id="fetchMd">Fetch</button>
-            </div>
-            <div class="testset-actions">
-                <select id="mdTableSelect">
-                    <option value="">No tables loaded...</option>
-                </select>
-                <button id="runMdTable" disabled>Run Table</button>
-            </div>
-            <div id="mdTableInfo" class="testset-info">
-                Enter a Markdown URL and click Fetch.
             </div>
         </div>
     </div>


### PR DESCRIPTION
Reordered the panels in `web/index.html` so that the "Markdown Test Cases" section now appears above the "Timing Diagram" section, as requested. Verified the change with visual inspection and existing frontend test suites.

Fixes #155

---
*PR created automatically by Jules for task [11955379114690493451](https://jules.google.com/task/11955379114690493451) started by @chatelao*