### PR TITLE
Propose Markdown test URL on project selection

### DIFF
--- a/test/test_md_proposal.py
+++ b/test/test_md_proposal.py
@@ -1,0 +1,125 @@
+import http.server
+import threading
+import socketserver
+import time
+from playwright.sync_api import sync_playwright
+
+PORT = 8006
+DIRECTORY = "web"
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=DIRECTORY, **kwargs)
+
+def start_server():
+    socketserver.TCPServer.allow_reuse_address = True
+    with socketserver.TCPServer(("", PORT), Handler) as httpd:
+        print(f"Serving at port {PORT}")
+        httpd.serve_forever()
+
+def test_md_proposal():
+    # Start the server in a separate thread
+    server_thread = threading.Thread(target=start_server, daemon=True)
+    server_thread.start()
+    time.sleep(2)  # Wait for server to start
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        # Use add_init_script to mock fetch BEFORE app.js runs
+        page.add_init_script("""
+            window.fetch = async (url) => {
+                const urlStr = (url && typeof url === 'object') ? url.url : url;
+                if (!urlStr) return { ok: false };
+
+                // Mock testset list
+                if (urlStr.includes('tt-test-framework/contents/src/data')) {
+                    return {
+                        ok: true,
+                        status: 200,
+                        json: async () => [
+                            {
+                                name: "tt3990_fp8_mul.yaml",
+                                download_url: "https://raw.githubusercontent.com/chatelao/tt-test-framework/main/src/data/tt3990_fp8_mul.yaml"
+                            }
+                        ]
+                    };
+                }
+
+                // Mock WASM engines list
+                if (urlStr.includes('tt-test-framework/contents/wasm')) {
+                    return {
+                        ok: true,
+                        status: 200,
+                        json: async () => []
+                    };
+                }
+
+                // Mock testset content
+                if (urlStr.includes('tt3990_fp8_mul.yaml')) {
+                    return {
+                        ok: true,
+                        status: 200,
+                        text: async () => `
+project: "OCP MXFP8 Streaming MAC Unit"
+metadata:
+  source: "https://github.com/chatelao/ttihp-fp8-mul"
+test_steps: []
+`
+                    };
+                }
+
+                // Mock GitHub Repo API
+                if (urlStr.includes('api.github.com/repos/chatelao/ttihp-fp8-mul')) {
+                    return {
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            default_branch: "ihp-sg13cmos5l"
+                        })
+                    };
+                }
+
+                return { ok: false, status: 404 };
+            };
+        """)
+
+        page.goto(f"http://localhost:{PORT}")
+
+        # Wait for testsets to load (use attached state because option might not be "visible" in the sense Playwright expects)
+        page.wait_for_selector("#testsetSelect option[value*='tt3990']", state="attached")
+
+        # Select the project
+        page.select_option("#testsetSelect", label="tt3990_fp8_mul.yaml")
+
+        # Load it
+        page.click("#loadTestset")
+
+        # Check if the MD URL was proposed correctly
+        # Proposed Markdown URL: https://github.com/chatelao/ttihp-fp8-mul/blob/ihp-sg13cmos5l/docs/test.md
+        expected_url = "https://github.com/chatelao/ttihp-fp8-mul/blob/ihp-sg13cmos5l/docs/test.md"
+
+        # Need to wait for the async fetch to complete and update the input
+        page.wait_for_function(f"document.getElementById('mdUrl').value === '{expected_url}'", timeout=5000)
+
+        proposed_url = page.input_value("#mdUrl")
+        assert proposed_url == expected_url
+        print(f"Verified Proposed URL: {proposed_url}")
+
+        # Now test the auto-load via wasm param
+        page.goto(f"http://localhost:{PORT}/?wasm=tt3990")
+
+        # No need to re-mock, add_init_script persists across navigations
+
+        # Wait for the auto-load to complete
+        page.wait_for_function(f"document.getElementById('mdUrl').value === '{expected_url}'", timeout=5000)
+        proposed_url_auto = page.input_value("#mdUrl")
+        assert proposed_url_auto == expected_url
+        print(f"Verified Auto-loaded Proposed URL: {proposed_url_auto}")
+
+        print("MD proposal test passed!")
+        browser.close()
+
+if __name__ == "__main__":
+    test_md_proposal()

--- a/web/app.js
+++ b/web/app.js
@@ -1063,7 +1063,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
             // Handle permalink
             const urlParams = new URLSearchParams(window.location.search);
-            const projectName = urlParams.get('project');
+            let projectName = urlParams.get('project');
+            const wasmName = urlParams.get('wasm');
+
+            if (!projectName && wasmName && wasmName !== 'default') {
+                // Try to find a testset starting with the wasm project ID (e.g. tt3990)
+                const options = Array.from(testsetSelect.options);
+                const targetOption = options.find(opt => opt.textContent.startsWith(wasmName));
+                if (targetOption) {
+                    projectName = targetOption.textContent.replace('.yaml', '');
+                    logToConsole(`Auto-loading testset for WASM engine: ${wasmName}`);
+                }
+            }
+
             if (projectName) {
                 logToConsole(`Permalink detected for project: ${projectName}`);
                 const options = Array.from(testsetSelect.options);
@@ -1344,6 +1356,9 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
+        // Clear previous proposed MD URL
+        mdUrlInput.value = '';
+
         try {
             logToConsole(`Loading testset from ${url}...`);
             const response = await fetch(url);
@@ -1372,16 +1387,49 @@ document.addEventListener('DOMContentLoaded', () => {
             testsetInfo.appendChild(projectDiv);
 
             if (currentTestset.metadata && currentTestset.metadata.source) {
+                const sourceUrl = currentTestset.metadata.source;
                 const sourceDiv = document.createElement('div');
                 const sourceLabel = document.createElement('strong');
                 sourceLabel.textContent = 'Source: ';
                 sourceDiv.appendChild(sourceLabel);
                 const sourceLink = document.createElement('a');
-                sourceLink.href = currentTestset.metadata.source;
+                sourceLink.href = sourceUrl;
                 sourceLink.target = '_blank';
-                sourceLink.textContent = currentTestset.metadata.source;
+                sourceLink.textContent = sourceUrl;
                 sourceDiv.appendChild(sourceLink);
                 testsetInfo.appendChild(sourceDiv);
+
+                // Propose Markdown test URL if source is GitHub
+                if (sourceUrl.includes('github.com')) {
+                    try {
+                        const urlObj = new URL(sourceUrl);
+                        const parts = urlObj.pathname.split('/').filter(p => p);
+                        if (parts.length >= 2) {
+                            const repoPath = `${parts[0]}/${parts[1]}`;
+                            logToConsole(`Proposing Markdown test URL for repository: ${repoPath}`);
+
+                            // Fetch default branch from GitHub API
+                            fetch(`https://api.github.com/repos/${repoPath}`)
+                                .then(res => res.ok ? res.json() : Promise.reject())
+                                .then(data => {
+                                    // Verify that we are still working on the same testset to avoid race conditions
+                                    if (currentTestset && currentTestset.metadata && currentTestset.metadata.source === sourceUrl) {
+                                        const defaultBranch = data.default_branch || 'main';
+                                        const proposedUrl = `https://github.com/${repoPath}/blob/${defaultBranch}/docs/test.md`;
+                                        mdUrlInput.value = proposedUrl;
+                                        logToConsole(`Proposed Markdown URL: ${proposedUrl}`);
+                                    }
+                                })
+                                .catch(err => {
+                                    console.error('Failed to fetch repo default branch', err);
+                                    const proposedUrl = `https://github.com/${repoPath}/blob/main/docs/test.md`;
+                                    mdUrlInput.value = proposedUrl;
+                                });
+                        }
+                    } catch (err) {
+                        console.error('Failed to parse source URL', err);
+                    }
+                }
             }
 
             if (currentTestset.test_steps) {


### PR DESCRIPTION
This change enhances the Tiny Tapeout Web Tester by automatically suggesting a Markdown test URL whenever a project is loaded. It dynamically determines the correct GitHub repository path and default branch using the GitHub API. Additionally, it improves project switching by auto-loading the corresponding testset when a WASM engine is selected via URL parameters. Logic was added to prevent displaying stale URLs and to handle potential race conditions during project switching.

Fixes #157

---
*PR created automatically by Jules for task [5117823443323957475](https://jules.google.com/task/5117823443323957475) started by @chatelao*