### PR TITLE
Synchronized Table Formatting and FP8 Variants

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -93,6 +93,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const useFullWasm = document.getElementById('useFullWasm');
     const wasmEngineSelect = document.getElementById('wasmEngineSelect');
 
+    const uoOutResult = document.getElementById('uo_out_result');
+    const uioOutResult = document.getElementById('uio_out_result');
+    const uioOeResult = document.getElementById('uio_oe_result');
+
     // Set dropdown value from current URL
     wasmEngineSelect.value = window.currentWasmEngine;
 
@@ -222,21 +226,117 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    // Column visibility toggles
-    ['uio_in', 'uio_out', 'uio_oe'].forEach(col => {
-        const toggle = document.getElementById(`toggle-${col}`);
-        toggle.addEventListener('change', () => {
-            if (toggle.checked) {
-                testerTable.classList.remove(`hide-${col}`);
-            } else {
-                testerTable.classList.add(`hide-${col}`);
-            }
-            updateDiagram();
-        });
-    });
     const historyData = [];
     let currentTestset = null;
     let cycleCount = 0;
+
+    function formatValue(value, type, channel) {
+        if (type === 'bits') {
+            return createBitDisplay(value);
+        }
+
+        const span = document.createElement('span');
+        if (type === 'hex') {
+            if (channel === 'cycle') {
+                span.textContent = `0x${value.toString(16).toUpperCase()}`;
+            } else {
+                span.textContent = `0x${value.toString(16).toUpperCase().padStart(2, '0')}`;
+            }
+        } else if (type === 'dec') {
+            span.textContent = value.toString();
+        } else if (type === 'bin') {
+            span.textContent = `0b${value.toString(2).padStart(8, '0')}`;
+        } else if (type === 'fp8_e4m3' || type === 'fp8') {
+            span.textContent = formatFP8_E4M3(value);
+        } else if (type === 'fp8_e3m4') {
+            span.textContent = formatFP8_E3M4(value);
+        } else if (type === 'dual_fp4') {
+            const high = formatFP4((value >> 4) & 0xF);
+            const low = formatFP4(value & 0xF);
+            span.textContent = `${high} | ${low}`;
+        } else if (type === 'binary' || type === 'show') {
+            span.textContent = value;
+        } else {
+            span.textContent = value;
+        }
+        return span;
+    }
+
+    function renderHistory() {
+        historyBody.innerHTML = '';
+        // Create a copy to reverse without affecting original
+        const data = [...historyData].reverse();
+        data.forEach(entry => {
+            const inputs = {
+                ui_in: entry.ui_in,
+                uio_in: entry.uio_in,
+                clk: entry.clk,
+                rst_n: entry.rst_n,
+                ena: entry.ena
+            };
+            const outputs = {
+                uo_out: entry.uo_out,
+                uio_out: entry.uio_out,
+                uio_oe: entry.uio_oe
+            };
+            addHistoryRow(inputs, outputs, entry.time, entry.cycle, true);
+        });
+    }
+
+    function updateInputRowResults() {
+        if (historyData.length === 0) return;
+        const last = historyData[historyData.length - 1];
+
+        const update = (id, val, ch) => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.innerHTML = '';
+            el.classList.remove('results-placeholder');
+            const typeSelect = document.getElementById(`table-type-${ch}`);
+            const type = typeSelect ? typeSelect.value : 'hex';
+            el.appendChild(formatValue(val, type, ch));
+        };
+
+        update('uo_out_result', last.uo_out, 'uo_out');
+        update('uio_out_result', last.uio_out, 'uio_out');
+        update('uio_oe_result', last.uio_oe, 'uio_oe');
+    }
+
+    // Column visibility and formatting sync
+    const channels = ['cycle', 'ui_in', 'uio_in', 'clk', 'rst_n', 'ena', 'uo_out', 'uio_out', 'uio_oe'];
+
+    channels.forEach(ch => {
+        const tableSelect = document.getElementById(`table-type-${ch}`);
+        const diagramSelect = document.getElementById(`type-${ch}`);
+
+        const handleSync = (src, dest) => {
+            if (!src || !dest) return;
+            dest.value = src.value;
+
+            // Handle visibility
+            if (src.value === 'hidden') {
+                testerTable.classList.add(`hide-${ch}`);
+            } else {
+                testerTable.classList.remove(`hide-${ch}`);
+            }
+
+            renderHistory();
+            updateInputRowResults();
+            updateDiagram();
+        };
+
+        if (tableSelect) {
+            tableSelect.addEventListener('change', () => handleSync(tableSelect, diagramSelect));
+        }
+        if (diagramSelect) {
+            diagramSelect.addEventListener('change', () => handleSync(diagramSelect, tableSelect));
+        }
+
+        // Initial visibility check
+        if (tableSelect && tableSelect.value === 'hidden') {
+            testerTable.classList.add(`hide-${ch}`);
+        }
+    });
 
     function updateURLParameter(projectName) {
         const url = new URL(window.location.href);
@@ -313,67 +413,48 @@ document.addEventListener('DOMContentLoaded', () => {
             span.textContent = bitVal;
             container.appendChild(span);
         }
-        const hexSpan = document.createElement('span');
-        hexSpan.className = 'hex-display';
-        hexSpan.textContent = `0x${value.toString(16).padStart(2, '0').toUpperCase()}`;
-        container.appendChild(hexSpan);
         return container;
     }
 
-    function addHistoryRow(inputs, outputs, timestamp, cycle) {
+    function addHistoryRow(inputs, outputs, timestamp, cycle, isRerender = false) {
         const row = document.createElement('tr');
 
-        // Time
-        const timeTd = document.createElement('td');
-        timeTd.className = 'time-cell';
-        timeTd.textContent = timestamp;
-        row.appendChild(timeTd);
+        const colConfigs = {
+            time: { val: timestamp, class: 'time-cell' },
+            cycle: { val: cycle, class: 'time-cell' },
+            ui_in: { val: inputs.ui_in },
+            uio_in: { val: inputs.uio_in },
+            clk: { val: inputs.clk },
+            rst_n: { val: inputs.rst_n },
+            ena: { val: inputs.ena },
+            uo_out: { val: outputs.uo_out },
+            uio_out: { val: outputs.uio_out },
+            uio_oe: { val: outputs.uio_oe }
+        };
 
-        // Cycle
-        const cycleTd = document.createElement('td');
-        cycleTd.className = 'time-cell';
-        cycleTd.textContent = cycle;
-        row.appendChild(cycleTd);
-
-        // ui_in
-        const uiInTd = document.createElement('td');
-        uiInTd.appendChild(createBitDisplay(inputs.ui_in));
-        row.appendChild(uiInTd);
-
-        // uio_in
-        const uioInTd = document.createElement('td');
-        uioInTd.className = 'col-uio_in';
-        uioInTd.appendChild(createBitDisplay(inputs.uio_in));
-        row.appendChild(uioInTd);
-
-        // clk, rst_n, ena
-        [inputs.clk, inputs.rst_n, inputs.ena].forEach(val => {
+        Object.keys(colConfigs).forEach(ch => {
+            const config = colConfigs[ch];
             const td = document.createElement('td');
-            td.textContent = val;
+            td.className = `col-${ch} ${config.class || ''}`;
+
+            if (ch === 'time') {
+                td.textContent = config.val;
+            } else {
+                const typeSelect = document.getElementById(`table-type-${ch}`);
+                const type = typeSelect ? typeSelect.value : 'dec';
+                td.appendChild(formatValue(config.val, type, ch));
+            }
             row.appendChild(td);
         });
 
-        // uo_out
-        const uoOutTd = document.createElement('td');
-        uoOutTd.appendChild(createBitDisplay(outputs.uo_out));
-        row.appendChild(uoOutTd);
-
-        // uio_out
-        const uioOutTd = document.createElement('td');
-        uioOutTd.className = 'col-uio_out';
-        uioOutTd.appendChild(createBitDisplay(outputs.uio_out));
-        row.appendChild(uioOutTd);
-
-        // uio_oe
-        const uioOeTd = document.createElement('td');
-        uioOeTd.className = 'col-uio_oe';
-        uioOeTd.appendChild(createBitDisplay(outputs.uio_oe));
-        row.appendChild(uioOeTd);
-
-        historyBody.prepend(row);
+        if (isRerender) {
+            historyBody.appendChild(row);
+        } else {
+            historyBody.prepend(row);
+        }
     }
 
-    function formatFP8(val) {
+    function formatFP8_E4M3(val) {
         // E4M3: 1 sign, 4 exponent, 3 mantissa, bias 7
         const sign = (val >> 7) & 1;
         const exponent = (val >> 3) & 0xF;
@@ -389,6 +470,23 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             // Normal
             result = (sign ? -1 : 1) * Math.pow(2, exponent - 7) * (1 + mantissa / 8);
+        }
+        return result.toFixed(3);
+    }
+
+    function formatFP8_E3M4(val) {
+        // E3M4: 1 sign, 3 exponent, 4 mantissa, bias 3
+        const sign = (val >> 7) & 1;
+        const exponent = (val >> 4) & 0x7;
+        const mantissa = val & 0xF;
+
+        let result = 0;
+        if (exponent === 0) {
+            // Subnormal
+            result = (sign ? -1 : 1) * Math.pow(2, -2) * (mantissa / 16);
+        } else {
+            // Normal
+            result = (sign ? -1 : 1) * Math.pow(2, exponent - 3) * (1 + mantissa / 16);
         }
         return result.toFixed(3);
     }
@@ -416,12 +514,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const channels = ['cycle', 'ui_in', 'uio_in', 'clk', 'rst_n', 'ena', 'uo_out', 'uio_out', 'uio_oe'];
         const config = {};
         channels.forEach(ch => {
-            let type = document.getElementById(`type-${ch}`).value;
-            const toggle = document.getElementById(`toggle-${ch}`);
-            if (toggle && !toggle.checked) {
-                type = 'hidden';
-            }
-            config[ch] = type;
+            const tableSelect = document.getElementById(`table-type-${ch}`);
+            config[ch] = tableSelect ? tableSelect.value : 'hex';
         });
 
         let puml = "@startuml\n";
@@ -485,8 +579,10 @@ document.addEventListener('DOMContentLoaded', () => {
                             puml += `${ch} is "${val}"\n`;
                         } else if (type === 'bin') {
                             puml += `${ch} is "0b${val.toString(2).padStart(8, '0')}"\n`;
-                        } else if (type === 'fp8') {
-                            puml += `${ch} is "${formatFP8(val)}"\n`;
+                        } else if (type === 'fp8_e4m3' || type === 'fp8') {
+                            puml += `${ch} is "${formatFP8_E4M3(val)}"\n`;
+                        } else if (type === 'fp8_e3m4') {
+                            puml += `${ch} is "${formatFP8_E3M4(val)}"\n`;
                         } else if (type === 'dual_fp4') {
                             const high = formatFP4((val >> 4) & 0xF);
                             const low = formatFP4(val & 0xF);
@@ -747,6 +843,9 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         addHistoryRow(inputs, outputs, timestamp, currentCycle);
+
+        updateInputRowResults();
+
         if (!skipUpdate) updateDiagram();
         return outputs;
     }
@@ -949,6 +1048,13 @@ document.addEventListener('DOMContentLoaded', () => {
         cycleCount = 0;
         historyBody.innerHTML = '';
         consoleDiv.textContent = '';
+
+        uoOutResult.textContent = 'Ready to send...';
+        uoOutResult.classList.add('results-placeholder');
+        uioOutResult.textContent = '';
+        uioOutResult.classList.add('results-placeholder');
+        uioOeResult.textContent = '';
+        uioOeResult.classList.add('results-placeholder');
 
         // Reset WASM DigitalTwin state if available
         if (digitalTwin) {
@@ -1235,7 +1341,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         let lastUi = getBits(uiIn);
         let lastUio = getBits(uioIn);
-        const rstVal = rstN.checked ? 1 : 0;
+        const rstNVal = rstN.checked ? 1 : 0;
         const enaVal = ena.checked ? 1 : 0;
         const clkSelection = clk.value;
 
@@ -1255,11 +1361,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 let results;
                 if (clkSelection === '1/0') {
-                    results = await performTransaction(uiVal, uioVal, 1, rstVal, enaVal);
-                    await performTransaction(uiVal, uioVal, 0, rstVal, enaVal);
+                    results = await performTransaction(uiVal, uioVal, 1, rstNVal, enaVal);
+                    await performTransaction(uiVal, uioVal, 0, rstNVal, enaVal);
                 } else {
                     const clkVal = parseInt(clkSelection);
-                    results = await performTransaction(uiVal, uioVal, clkVal, rstVal, enaVal);
+                    results = await performTransaction(uiVal, uioVal, clkVal, rstNVal, enaVal);
                 }
 
                 // Verification
@@ -1313,7 +1419,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Initial state from UI
         let uiVal = getBits(uiIn);
         let uioVal = getBits(uioIn);
-        let rstVal = rstN.checked ? 1 : 0;
+        let rstNVal = rstN.checked ? 1 : 0;
         let enaVal = ena.checked ? 1 : 0;
         let clkVal = 0; // Start with clk low for consistency
         const clkSelection = clk.value;
@@ -1325,7 +1431,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (step.values) {
                 if (step.values.ui_in !== undefined) uiVal = step.values.ui_in & 0xFF;
                 if (step.values.uio_in !== undefined) uioVal = step.values.uio_in & 0xFF;
-                if (step.values.rst_n !== undefined) rstVal = step.values.rst_n ? 1 : 0;
+                if (step.values.rst_n !== undefined) rstNVal = step.values.rst_n ? 1 : 0;
                 if (step.values.ena !== undefined) enaVal = step.values.ena ? 1 : 0;
             }
 
@@ -1334,12 +1440,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (clkSelection === '1/0') {
                     // Toggle clock
                     clkVal = 1;
-                    await performTransaction(uiVal, uioVal, clkVal, rstVal, enaVal);
+                    await performTransaction(uiVal, uioVal, clkVal, rstNVal, enaVal);
                     clkVal = 0;
-                    await performTransaction(uiVal, uioVal, clkVal, rstVal, enaVal);
+                    await performTransaction(uiVal, uioVal, clkVal, rstNVal, enaVal);
                 } else {
                     clkVal = parseInt(clkSelection);
-                    await performTransaction(uiVal, uioVal, clkVal, rstVal, enaVal);
+                    await performTransaction(uiVal, uioVal, clkVal, rstNVal, enaVal);
                 }
                 // Yield to main thread
                 await new Promise(r => setTimeout(r, 0));

--- a/web/index.html
+++ b/web/index.html
@@ -30,32 +30,108 @@
             <table class="tester-table">
                 <thead>
                     <tr>
-                        <th>Time</th>
-                        <th>Cycle</th>
-                        <th>ui_in [7:0]</th>
-                        <th class="col-uio_in">
-                            <input type="checkbox" id="toggle-uio_in" checked title="Toggle uio_in visibility">
-                            uio_in [7:0]
+                        <th class="col-time">Time</th>
+                        <th class="col-cycle">
+                            Cycle
+                            <select id="table-type-cycle" class="table-type">
+                                <option value="dec" selected>Dec</option>
+                                <option value="hex">Hex</option>
+                                <option value="hidden">Hidden</option>
+                            </select>
                         </th>
-                        <th>clk</th>
-                        <th>rst_n</th>
-                        <th>ena</th>
-                        <th>uo_out [7:0]</th>
+                        <th class="col-ui_in">
+                            ui_in [7:0]
+                            <select id="table-type-ui_in" class="table-type">
+                                <option value="hex" selected>Hex</option>
+                                <option value="dec">Dec</option>
+                                <option value="bin">Bin</option>
+                                <option value="bits">Bits</option>
+                                <option value="fp8_e4m3">FP8 (E4M3)</option>
+                                <option value="fp8_e3m4">FP8 (E3M4)</option>
+                                <option value="dual_fp4">Dual FP4</option>
+                                <option value="hidden">Hidden</option>
+                            </select>
+                        </th>
+                        <th class="col-uio_in">
+                            uio_in [7:0]
+                            <select id="table-type-uio_in" class="table-type">
+                                <option value="hex" selected>Hex</option>
+                                <option value="dec">Dec</option>
+                                <option value="bin">Bin</option>
+                                <option value="bits">Bits</option>
+                                <option value="fp8_e4m3">FP8 (E4M3)</option>
+                                <option value="fp8_e3m4">FP8 (E3M4)</option>
+                                <option value="dual_fp4">Dual FP4</option>
+                                <option value="hidden">Hidden</option>
+                            </select>
+                        </th>
+                        <th class="col-clk">
+                            clk
+                            <select id="table-type-clk" class="table-type">
+                                <option value="binary" selected>Show</option>
+                                <option value="hidden">Hide</option>
+                            </select>
+                        </th>
+                        <th class="col-rst_n">
+                            rst_n
+                            <select id="table-type-rst_n" class="table-type">
+                                <option value="binary" selected>Show</option>
+                                <option value="hidden">Hide</option>
+                            </select>
+                        </th>
+                        <th class="col-ena">
+                            ena
+                            <select id="table-type-ena" class="table-type">
+                                <option value="binary" selected>Show</option>
+                                <option value="hidden">Hide</option>
+                            </select>
+                        </th>
+                        <th class="col-uo_out">
+                            uo_out [7:0]
+                            <select id="table-type-uo_out" class="table-type">
+                                <option value="hex" selected>Hex</option>
+                                <option value="dec">Dec</option>
+                                <option value="bin">Bin</option>
+                                <option value="bits">Bits</option>
+                                <option value="fp8_e4m3">FP8 (E4M3)</option>
+                                <option value="fp8_e3m4">FP8 (E3M4)</option>
+                                <option value="dual_fp4">Dual FP4</option>
+                                <option value="hidden">Hidden</option>
+                            </select>
+                        </th>
                         <th class="col-uio_out">
-                            <input type="checkbox" id="toggle-uio_out" checked title="Toggle uio_out visibility">
                             uio_out [7:0]
+                            <select id="table-type-uio_out" class="table-type">
+                                <option value="hex" selected>Hex</option>
+                                <option value="dec">Dec</option>
+                                <option value="bin">Bin</option>
+                                <option value="bits">Bits</option>
+                                <option value="fp8_e4m3">FP8 (E4M3)</option>
+                                <option value="fp8_e3m4">FP8 (E3M4)</option>
+                                <option value="dual_fp4">Dual FP4</option>
+                                <option value="hidden">Hidden</option>
+                            </select>
                         </th>
                         <th class="col-uio_oe">
-                            <input type="checkbox" id="toggle-uio_oe" checked title="Toggle uio_oe visibility">
                             uio_oe [7:0]
+                            <select id="table-type-uio_oe" class="table-type">
+                                <option value="hex" selected>Hex</option>
+                                <option value="dec">Dec</option>
+                                <option value="bin">Bin</option>
+                                <option value="bits">Bits</option>
+                                <option value="fp8_e4m3">FP8 (E4M3)</option>
+                                <option value="fp8_e3m4">FP8 (E3M4)</option>
+                                <option value="dual_fp4">Dual FP4</option>
+                                <option value="hidden">Hidden</option>
+                            </select>
                         </th>
                     </tr>
                 </thead>
                 <tbody class="input-section">
                     <tr class="input-row">
-                        <td class="time-cell">-</td>
-                        <td class="time-cell">-</td>
-                        <td>
+                        <td class="col-time time-cell">-</td>
+                        <td class="col-cycle time-cell">-</td>
+                        <td class="col-ui_in">
                             <div class="bits-container">
                                 <div class="bits" id="ui_in">
                                     <input type="checkbox" title="7"><input type="checkbox" title="6"><input type="checkbox" title="5"><input type="checkbox" title="4"><input type="checkbox" title="3"><input type="checkbox" title="2"><input type="checkbox" title="1"><input type="checkbox" title="0">
@@ -79,18 +155,18 @@
                                 </div>
                             </div>
                         </td>
-                        <td class="center-cell">
+                        <td class="col-clk center-cell">
                             <select id="clk">
                                 <option value="0">0</option>
                                 <option value="1">1</option>
                                 <option value="1/0" selected>1/0</option>
                             </select>
                         </td>
-                        <td class="center-cell"><input type="checkbox" id="rst_n" checked></td>
-                        <td class="center-cell"><input type="checkbox" id="ena" checked></td>
-                        <td class="results-placeholder">Ready to send...</td>
-                        <td class="col-uio_out results-placeholder"></td>
-                        <td class="col-uio_oe results-placeholder"></td>
+                        <td class="col-rst_n center-cell"><input type="checkbox" id="rst_n" checked></td>
+                        <td class="col-ena center-cell"><input type="checkbox" id="ena" checked></td>
+                        <td class="col-uo_out results-placeholder" id="uo_out_result">Ready to send...</td>
+                        <td class="col-uio_out results-placeholder" id="uio_out_result"></td>
+                        <td class="col-uio_oe results-placeholder" id="uio_oe_result"></td>
                     </tr>
                 </tbody>
                 <tbody id="history">
@@ -120,7 +196,7 @@
             </div>
             <div class="testset-actions">
                 <select id="mdTableSelect">
-                    <option value="">No tables loaded...</option>
+                    <option value="">Select a table...</option>
                 </select>
                 <button id="runMdTable" disabled>Run Table</button>
             </div>
@@ -147,7 +223,8 @@
                         <option value="dec">Dec</option>
                         <option value="bin">Bin</option>
                         <option value="bits">Bits</option>
-                        <option value="fp8">FP8</option>
+                        <option value="fp8_e4m3">FP8 (E4M3)</option>
+                        <option value="fp8_e3m4">FP8 (E3M4)</option>
                         <option value="dual_fp4">Dual FP4</option>
                         <option value="hidden">Hidden</option>
                     </select>
@@ -159,7 +236,8 @@
                         <option value="dec">Dec</option>
                         <option value="bin">Bin</option>
                         <option value="bits">Bits</option>
-                        <option value="fp8">FP8</option>
+                        <option value="fp8_e4m3">FP8 (E4M3)</option>
+                        <option value="fp8_e3m4">FP8 (E3M4)</option>
                         <option value="dual_fp4">Dual FP4</option>
                         <option value="hidden">Hidden</option>
                     </select>
@@ -192,7 +270,8 @@
                         <option value="dec">Dec</option>
                         <option value="bin">Bin</option>
                         <option value="bits">Bits</option>
-                        <option value="fp8">FP8</option>
+                        <option value="fp8_e4m3">FP8 (E4M3)</option>
+                        <option value="fp8_e3m4">FP8 (E3M4)</option>
                         <option value="dual_fp4">Dual FP4</option>
                         <option value="hidden">Hidden</option>
                     </select>
@@ -204,7 +283,8 @@
                         <option value="dec">Dec</option>
                         <option value="bin">Bin</option>
                         <option value="bits">Bits</option>
-                        <option value="fp8">FP8</option>
+                        <option value="fp8_e4m3">FP8 (E4M3)</option>
+                        <option value="fp8_e3m4">FP8 (E3M4)</option>
                         <option value="dual_fp4">Dual FP4</option>
                         <option value="hidden">Hidden</option>
                     </select>
@@ -216,7 +296,8 @@
                         <option value="dec">Dec</option>
                         <option value="bin">Bin</option>
                         <option value="bits">Bits</option>
-                        <option value="fp8">FP8</option>
+                        <option value="fp8_e4m3">FP8 (E4M3)</option>
+                        <option value="fp8_e3m4">FP8 (E3M4)</option>
                         <option value="dual_fp4">Dual FP4</option>
                         <option value="hidden">Hidden</option>
                     </select>

--- a/web/style.css
+++ b/web/style.css
@@ -76,25 +76,29 @@ h1 {
     background-color: #f8f9fa;
     font-weight: bold;
     font-size: 0.85rem;
+    vertical-align: top;
+}
+
+.table-type {
+    display: block;
+    margin: 4px auto 0;
+    font-size: 0.75rem;
+    padding: 2px;
+    font-weight: normal;
+    font-family: sans-serif;
 }
 
 /* Column hiding styles */
-.tester-table.hide-uio_in .col-uio_in > *:not(input[type="checkbox"]),
-.tester-table.hide-uio_out .col-uio_out > *:not(input[type="checkbox"]),
-.tester-table.hide-uio_oe .col-uio_oe > *:not(input[type="checkbox"]) {
+.tester-table.hide-cycle .col-cycle,
+.tester-table.hide-ui_in .col-ui_in,
+.tester-table.hide-uio_in .col-uio_in,
+.tester-table.hide-clk .col-clk,
+.tester-table.hide-rst_n .col-rst_n,
+.tester-table.hide-ena .col-ena,
+.tester-table.hide-uo_out .col-uo_out,
+.tester-table.hide-uio_out .col-uio_out,
+.tester-table.hide-uio_oe .col-uio_oe {
     display: none;
-}
-
-.tester-table.hide-uio_in td.col-uio_in,
-.tester-table.hide-uio_out td.col-uio_out,
-.tester-table.hide-uio_oe td.col-uio_oe {
-    background-color: #f0f0f0;
-}
-
-.tester-table input[type="checkbox"][id^="toggle-"] {
-    margin-right: 4px;
-    vertical-align: middle;
-    cursor: pointer;
 }
 
 .input-row {


### PR DESCRIPTION
I have implemented synchronized format dropdowns for all columns in the Tiny Tapeout Web Tester table.

### Changes:
1.  **Tester Table Enhancements**:
    *   Added a format selection dropdown to every column header in the history table.
    *   Added standard classes (`col-time`, `col-cycle`, etc.) to all table cells for robust targeting.
    *   Implemented full column hiding when a column is set to "Hidden" in its dropdown.
2.  **Formatting Logic**:
    *   Introduced a reusable `formatValue` function in `web/app.js` to handle all signal formatting (Hex, Dec, Bin, Bits, Dual FP4).
    *   Added specialized support for **FP8 (E4M3)** and **FP8 (E3M4)** variants with correct bit-widths and biases.
    *   Ensured the "read-only" results in the primary input row are updated with the selected format immediately after a transaction.
3.  **Synchronization**:
    *   Implemented a two-way sync between the table header dropdowns and the timing diagram controls. Changing one automatically updates the other and refreshes both the table and the diagram.
4.  **UI/UX Improvements**:
    *   Styled the new dropdowns to be compact and unobtrusive.
    *   Replaced the old visibility checkboxes with the more integrated dropdown-based hiding mechanism.

I verified the changes using automated Playwright tests and a dedicated visual verification script that confirms the formatting and synchronization work as expected.

Fixes #159

---
*PR created automatically by Jules for task [10543123601034926313](https://jules.google.com/task/10543123601034926313) started by @chatelao*