### PR TITLE
Support column types in Markdown table headers

### DIFF
--- a/test/test_markdown_column_types.py
+++ b/test/test_markdown_column_types.py
@@ -1,0 +1,92 @@
+import http.server
+import threading
+import socketserver
+import os
+import time
+from playwright.sync_api import sync_playwright
+
+PORT = 8006
+DIRECTORY = "web"
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=DIRECTORY, **kwargs)
+
+def start_server():
+    socketserver.TCPServer.allow_reuse_address = True
+    with socketserver.TCPServer(("", PORT), Handler) as httpd:
+        print(f"Serving at port {PORT}")
+        httpd.serve_forever()
+
+def test_markdown_column_types():
+    # Start the server in a separate thread
+    server_thread = threading.Thread(target=start_server, daemon=True)
+    server_thread.start()
+    time.sleep(2)  # Wait for server to start
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(f"http://localhost:{PORT}")
+
+        # Mock the fetch
+        page.evaluate("""
+            window.fetch = async (url) => {
+                let urlStr = url;
+                if (url && typeof url === 'object') {
+                    urlStr = url.url || url.toString();
+                }
+
+                if (typeof urlStr === 'string') {
+                    if (urlStr.includes('test_types.md')) {
+                        return {
+                            ok: true,
+                            text: async () => `
+# Type Test
+| Cycle | ui_in (E4M3) | uio_in (Bits) | uo_out (Dual FP4) | Description |
+|:---:|:---:|:---:|:---:|---|
+| 0 | 0x38 | 0xAA | 0x00 | Test |
+`
+                        };
+                    }
+                    if (urlStr.includes('api.github.com')) {
+                        return {
+                            ok: true,
+                            json: async () => []
+                        };
+                    }
+                }
+                return { ok: false, status: 404 };
+            };
+        """)
+
+        page.fill("#mdUrl", "https://example.com/test_types.md")
+        page.click("#fetchMd")
+
+        # Wait for table to be loaded in dropdown
+        page.wait_for_selector("#mdTableSelect option[value='0-0']", state="attached")
+
+        # Select the table
+        page.select_option("#mdTableSelect", "0-0")
+
+        # Run the table
+        page.click("#runMdTable")
+
+        # Verify dropdowns
+        ui_in_type = page.eval_on_selector("#table-type-ui_in", "el => el.value")
+        uio_in_type = page.eval_on_selector("#table-type-uio_in", "el => el.value")
+        uo_out_type = page.eval_on_selector("#table-type-uo_out", "el => el.value")
+
+        print(f"ui_in type: {ui_in_type}")
+        print(f"uio_in type: {uio_in_type}")
+        print(f"uo_out type: {uo_out_type}")
+
+        assert ui_in_type == "fp8_e4m3"
+        assert uio_in_type == "bits"
+        assert uo_out_type == "dual_fp4"
+
+        print("Markdown column types test passed!")
+        browser.close()
+
+if __name__ == "__main__":
+    test_markdown_column_types()

--- a/web/app.js
+++ b/web/app.js
@@ -1329,14 +1329,48 @@ document.addEventListener('DOMContentLoaded', () => {
         runMdTableBtn.disabled = true;
 
         const colMap = {};
+        const typeMapping = {
+            'e4m3': 'fp8_e4m3',
+            'fp8': 'fp8_e4m3',
+            'fp8 (e4m3)': 'fp8_e4m3',
+            'e3m4': 'fp8_e3m4',
+            'fp8 (e3m4)': 'fp8_e3m4',
+            'dual e2m1': 'dual_fp4',
+            'dual fp4': 'dual_fp4',
+            'hex': 'hex',
+            'dec': 'dec',
+            'bin': 'bin',
+            'bits': 'bits'
+        };
+
         table.headers.forEach((h, idx) => {
             const header = h.toLowerCase();
-            if (header.includes('ui_in')) colMap.ui_in = idx;
-            if (header.includes('uio_in')) colMap.uio_in = idx;
-            if (header.includes('uo_out')) colMap.uo_out = idx;
-            if (header.includes('uio_out')) colMap.uio_out = idx;
-            if (header.includes('uio_oe')) colMap.uio_oe = idx;
-            if (header.includes('cycle')) colMap.cycle = idx;
+            let channel = null;
+
+            if (header.includes('uio_in')) channel = 'uio_in';
+            else if (header.includes('ui_in')) channel = 'ui_in';
+            else if (header.includes('uio_out')) channel = 'uio_out';
+            else if (header.includes('uo_out')) channel = 'uo_out';
+            else if (header.includes('uio_oe')) channel = 'uio_oe';
+            else if (header.includes('cycle')) channel = 'cycle';
+
+            if (channel) {
+                colMap[channel] = idx;
+
+                // Extract type in parentheses
+                const typeMatch = h.match(/\(([^)]+)\)/);
+                if (typeMatch) {
+                    const typeStr = typeMatch[1].toLowerCase().trim();
+                    const mappedType = typeMapping[typeStr];
+                    if (mappedType) {
+                        const typeSelect = document.getElementById(`table-type-${channel}`);
+                        if (typeSelect) {
+                            typeSelect.value = mappedType;
+                            typeSelect.dispatchEvent(new Event('change'));
+                        }
+                    }
+                }
+            }
         });
 
         let lastUi = getBits(uiIn);


### PR DESCRIPTION
Support for column type annotations in Markdown table headers (e.g., `ui_in (E4M3)`) has been implemented in `web/app.js`. This allows the Web Tester to automatically switch the display format for signals when a Markdown table is run. The implementation includes:
- A regex-based extraction of text within parentheses in headers.
- A mapping of these strings to internal type identifiers.
- Automatic update and synchronization of UI dropdowns for the affected channels.
- Hardened channel matching logic to prevent substring collisions between `ui_in` and `uio_in`.
- Verification via a new Playwright test `test/test_markdown_column_types.py`.

Fixes #161

---
*PR created automatically by Jules for task [2204234014122012898](https://jules.google.com/task/2204234014122012898) started by @chatelao*