### PR TITLE
Add Grouped column for multi-cycle data aggregation

### DIFF
--- a/test/test_grouped_column.py
+++ b/test/test_grouped_column.py
@@ -1,0 +1,88 @@
+import time
+import subprocess
+from playwright.sync_api import sync_playwright
+
+def test_grouped_column():
+    # Start local server
+    server_process = subprocess.Popen(['python3', '-m', 'http.server', '8000'], cwd='web')
+    time.sleep(2)  # Give server time to start
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto('http://localhost:8000/index.html')
+
+            # 1. Set clk to 1/0 mode
+            page.select_option('#clk', '1/0')
+
+            # 2. Perform 4 transactions with specific ui_in values
+            # Since uio_in is 0 and it's XOR mode by default, uo_out will match ui_in
+            test_values = [0xAA, 0xBB, 0xCC, 0xDD]
+
+            for val in test_values:
+                # Set ui_in_hex
+                page.fill('#ui_in_hex', f'{val:02X}')
+                page.press('#ui_in_hex', 'Enter')
+                # Click Send
+                page.click('#sendReceive')
+                # Wait for history row to appear
+                page.wait_for_selector(f'#history tr td:has-text("0x{val:02X}")')
+
+            # 3. Enable Grouped column and configure it
+            # Need to use force=True or ensure it's visible if hidden by CSS
+            # But select_option usually works on hidden elements if we are careful,
+            # however Playwright waits for visibility.
+            # Let's use dispatchEvent or set it via JS if it's "hidden" by class.
+            page.evaluate("document.getElementById('table-type-grouped').value = 'hex'")
+            page.evaluate("document.getElementById('table-type-grouped').dispatchEvent(new Event('change'))")
+            # All these selectors are in the same header which might be considered "not visible" if it's too small or something,
+            # but they should be visible now that 'hidden' is gone from #table-type-grouped.
+            # However, if the column itself is still "display: none" during the transition, Playwright might complain.
+            # Let's use evaluate for all of them to be safe and fast.
+            page.evaluate("document.getElementById('table-type-grouped-signal').value = 'uo_out'")
+            page.evaluate("document.getElementById('table-type-grouped-signal').dispatchEvent(new Event('change'))")
+            page.evaluate("document.getElementById('table-type-grouped-size').value = '4'")
+            page.evaluate("document.getElementById('table-type-grouped-size').dispatchEvent(new Event('change'))")
+
+            # 4. Verify grouped_result in input-row
+            # The expected value should be 0xDDCCBBAA (most recent is least significant byte in my implementation)
+            # wait, let's re-read getGroupedValue logic
+            # for (let i = historyIndex; i >= 0; i--) { ...
+            #   const shift = BigInt(cyclesFound * 8);
+            #   value |= BigInt(entry[signal]) << shift;
+            #   cyclesFound++;
+            # }
+            # So historyData[last] is shift 0, historyData[last-2] (previous falling edge) is shift 8, etc.
+            # My performTransaction in 1/0 mode does clk=1 then clk=0.
+            # So test_values[3] (0xDD) results in TWO rows. The second row has clk=0 (falling edge).
+            # test_values[2] (0xCC) results in TWO rows. The fourth row from top has clk=0.
+
+            # Expected: 0xAABBCCDD (Oldest is MSB)
+            expected_grouped_hex = "0xAABBCCDD"
+
+            # Debug: print what we have
+            time.sleep(2)
+            actual_text = page.inner_text('#grouped_result')
+            print(f"Actual grouped result: '{actual_text}'")
+
+            # Use wait_for_function to ensure the value is updated
+            page.wait_for_function(f'document.getElementById("grouped_result").innerText.includes("{expected_grouped_hex}")')
+
+            grouped_text = page.inner_text('#grouped_result')
+            print(f"Grouped Result: {grouped_text}")
+            assert expected_grouped_hex in grouped_text
+
+            # 5. Check history rows
+            # The top row should have the same grouped value
+            history_grouped = page.inner_text('#history tr:first-child .col-grouped')
+            print(f"History Top Row Grouped: {history_grouped}")
+            assert expected_grouped_hex in history_grouped
+
+            print("Grouped Column Verification Passed!")
+
+    finally:
+        server_process.terminate()
+
+if __name__ == '__main__':
+    test_grouped_column()

--- a/web/app.js
+++ b/web/app.js
@@ -238,8 +238,38 @@ document.addEventListener('DOMContentLoaded', () => {
     const historyData = [];
     let cycleCount = 0;
 
+    function getGroupedValue(historyIndex, signal, numCycles) {
+        let value = 0n;
+        let cyclesFound = 0;
+        let foundAny = false;
+
+        // Traverse backwards from historyIndex
+        for (let i = historyIndex; i >= 0; i--) {
+            const entry = historyData[i];
+            const prevEntry = i > 0 ? historyData[i - 1] : null;
+
+            // Detect falling edge of clk (1 -> 0)
+            const isFallingEdge = (entry.clk === 0 && (!prevEntry || prevEntry.clk === 1));
+
+            if (isFallingEdge) {
+                const shift = BigInt(cyclesFound * 8);
+                value |= BigInt(entry[signal]) << shift;
+                cyclesFound++;
+                foundAny = true;
+                if (cyclesFound >= numCycles) break;
+            }
+        }
+
+        return foundAny ? value : 0n;
+    }
+
     function formatValue(value, type, channel) {
         if (type === 'bits') {
+            if (channel === 'grouped') {
+                const sizeSelect = document.getElementById('table-type-grouped-size');
+                const numCycles = sizeSelect ? parseInt(sizeSelect.value) : 4;
+                return createBitDisplay(value, numCycles * 8);
+            }
             return createBitDisplay(value);
         }
 
@@ -247,13 +277,19 @@ document.addEventListener('DOMContentLoaded', () => {
         if (type === 'hex') {
             if (channel === 'cycle') {
                 span.textContent = `0x${value.toString(16).toUpperCase()}`;
+            } else if (channel === 'grouped') {
+                span.textContent = `0x${value.toString(16).toUpperCase()}`;
             } else {
                 span.textContent = `0x${value.toString(16).toUpperCase().padStart(2, '0')}`;
             }
         } else if (type === 'dec') {
             span.textContent = value.toString();
         } else if (type === 'bin') {
-            span.textContent = `0b${value.toString(2).padStart(8, '0')}`;
+            if (channel === 'grouped') {
+                span.textContent = `0b${value.toString(2)}`;
+            } else {
+                span.textContent = `0b${value.toString(2).padStart(8, '0')}`;
+            }
         } else if (type === 'fp8_e4m3' || type === 'fp8') {
             span.textContent = formatFP8_E4M3(value);
         } else if (type === 'fp8_e3m4') {
@@ -282,9 +318,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function renderHistory() {
         historyBody.innerHTML = '';
-        // Create a copy to reverse without affecting original
-        const data = [...historyData].reverse();
-        data.forEach(entry => {
+        // Iterate through historyData in reverse order for display
+        for (let i = historyData.length - 1; i >= 0; i--) {
+            const entry = historyData[i];
             const inputs = {
                 ui_in: entry.ui_in,
                 uio_in: entry.uio_in,
@@ -297,8 +333,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 uio_out: entry.uio_out,
                 uio_oe: entry.uio_oe
             };
-            addHistoryRow(inputs, outputs, entry.time, entry.cycle, true);
-        });
+            addHistoryRow(inputs, outputs, entry.time, entry.cycle, true, i);
+        }
     }
 
     function updateInputRowResults() {
@@ -318,18 +354,24 @@ document.addEventListener('DOMContentLoaded', () => {
         update('uo_out_result', last.uo_out, 'uo_out');
         update('uio_out_result', last.uio_out, 'uio_out');
         update('uio_oe_result', last.uio_oe, 'uio_oe');
+
+        const groupedSignal = document.getElementById('table-type-grouped-signal').value;
+        const groupedSize = parseInt(document.getElementById('table-type-grouped-size').value);
+        const groupedValue = getGroupedValue(historyData.length - 1, groupedSignal, groupedSize);
+        update('grouped_result', groupedValue, 'grouped');
     }
 
     // Column visibility and formatting sync
-    const channels = ['cycle', 'ui_in', 'uio_in', 'clk', 'rst_n', 'ena', 'uo_out', 'uio_out', 'uio_oe'];
+    const channels = ['cycle', 'ui_in', 'uio_in', 'clk', 'rst_n', 'ena', 'uo_out', 'uio_out', 'uio_oe', 'grouped'];
 
     channels.forEach(ch => {
         const tableSelect = document.getElementById(`table-type-${ch}`);
+        // table-type-grouped has no direct diagram counterpart in the same way, but it shares the name
         const diagramSelect = document.getElementById(`type-${ch}`);
 
         const handleSync = (src, dest) => {
-            if (!src || !dest) return;
-            dest.value = src.value;
+            if (!src) return;
+            if (dest) dest.value = src.value;
 
             // Handle visibility
             if (src.value === 'hidden') {
@@ -354,6 +396,14 @@ document.addEventListener('DOMContentLoaded', () => {
         if (tableSelect && tableSelect.value === 'hidden') {
             testerTable.classList.add(`hide-${ch}`);
         }
+    });
+
+    // Special listeners for grouped configuration
+    ['table-type-grouped-signal', 'table-type-grouped-size'].forEach(id => {
+        document.getElementById(id).addEventListener('change', () => {
+            renderHistory();
+            updateInputRowResults();
+        });
     });
 
 
@@ -412,11 +462,16 @@ document.addEventListener('DOMContentLoaded', () => {
         updateBitsFromHex(uioInHex, uioIn);
     });
 
-    function createBitDisplay(value) {
+    function createBitDisplay(value, size = 8) {
         const container = document.createElement('div');
         container.className = 'bits-out';
-        for (let i = 0; i < 8; i++) {
-            const bitVal = (value >> (7 - i)) & 1;
+        for (let i = 0; i < size; i++) {
+            let bitVal;
+            if (typeof value === 'bigint') {
+                bitVal = (value >> BigInt(size - 1 - i)) & 1n;
+            } else {
+                bitVal = (value >> (size - 1 - i)) & 1;
+            }
             const span = document.createElement('span');
             span.className = 'bit' + (bitVal ? ' high' : '');
             span.textContent = bitVal;
@@ -425,8 +480,16 @@ document.addEventListener('DOMContentLoaded', () => {
         return container;
     }
 
-    function addHistoryRow(inputs, outputs, timestamp, cycle, isRerender = false) {
+    function addHistoryRow(inputs, outputs, timestamp, cycle, isRerender = false, historyIndex = -1) {
         const row = document.createElement('tr');
+
+        if (historyIndex === -1) {
+            historyIndex = historyData.length - 1;
+        }
+
+        const groupedSignal = document.getElementById('table-type-grouped-signal').value;
+        const groupedSize = parseInt(document.getElementById('table-type-grouped-size').value);
+        const groupedValue = getGroupedValue(historyIndex, groupedSignal, groupedSize);
 
         const colConfigs = {
             time: { val: timestamp, class: 'time-cell' },
@@ -438,7 +501,8 @@ document.addEventListener('DOMContentLoaded', () => {
             ena: { val: inputs.ena },
             uo_out: { val: outputs.uo_out },
             uio_out: { val: outputs.uio_out },
-            uio_oe: { val: outputs.uio_oe }
+            uio_oe: { val: outputs.uio_oe },
+            grouped: { val: groupedValue }
         };
 
         Object.keys(colConfigs).forEach(ch => {

--- a/web/index.html
+++ b/web/index.html
@@ -126,6 +126,28 @@
                                 <option value="hidden">Hidden</option>
                             </select>
                         </th>
+                        <th class="col-grouped">
+                            Grouped
+                            <select id="table-type-grouped-signal" class="table-type">
+                                <option value="ui_in">ui_in</option>
+                                <option value="uio_in">uio_in</option>
+                                <option value="uo_out" selected>uo_out</option>
+                                <option value="uio_out">uio_out</option>
+                            </select>
+                            <select id="table-type-grouped-size" class="table-type">
+                                <option value="2">2 cycles</option>
+                                <option value="4" selected>4 cycles</option>
+                                <option value="8">8 cycles</option>
+                                <option value="16">16 cycles</option>
+                            </select>
+                            <select id="table-type-grouped" class="table-type">
+                                <option value="hex">Hex</option>
+                                <option value="dec">Dec</option>
+                                <option value="bin">Bin</option>
+                                <option value="bits">Bits</option>
+                                <option value="hidden" selected>Hidden</option>
+                            </select>
+                        </th>
                     </tr>
                 </thead>
                 <tbody class="input-section">
@@ -168,6 +190,7 @@
                         <td class="col-uo_out results-placeholder" id="uo_out_result">Ready to send...</td>
                         <td class="col-uio_out results-placeholder" id="uio_out_result"></td>
                         <td class="col-uio_oe results-placeholder" id="uio_oe_result"></td>
+                        <td class="col-grouped results-placeholder" id="grouped_result"></td>
                     </tr>
                 </tbody>
                 <tbody id="history">

--- a/web/style.css
+++ b/web/style.css
@@ -97,7 +97,8 @@ h1 {
 .tester-table.hide-ena .col-ena,
 .tester-table.hide-uo_out .col-uo_out,
 .tester-table.hide-uio_out .col-uio_out,
-.tester-table.hide-uio_oe .col-uio_oe {
+.tester-table.hide-uio_oe .col-uio_oe,
+.tester-table.hide-grouped .col-grouped {
     display: none;
 }
 


### PR DESCRIPTION
This PR adds a new 'Grouped' column to the Tiny Tapeout Web Tester interface. This feature allows users to group data from multiple clock cycles (2, 4, 8, or 16) into a single wide-bit value, which is particularly useful for debugging systolic arrays or other designs that process data over several cycles.

Key changes:
- **UI**: A new 'Grouped' column header in `web/index.html` with dropdowns to select the source signal (ui_in, uio_in, uo_out, uio_out), the grouping size, and the display format.
- **Logic**: A new `getGroupedValue` function in `web/app.js` that traverses the transaction history backwards, identifying "data cycles" by falling clock edges (1 -> 0 transition).
- **BigInt Support**: Replaced standard number bitwise operations with `BigInt` logic in `getGroupedValue`, `formatValue`, and `createBitDisplay` to correctly handle up to 128-bit values.
- **Synchronization**: Integrated the new column into the existing visibility and formatting synchronization system.
- **Verification**: Included a new Playwright test `test/test_grouped_column.py` that verifies the feature by driving a sequence of inputs and checking the aggregated hex output in the UI.

Visual verification (screenshot and video) was performed to ensure the UI remains responsive and the data aggregation is accurate.

Fixes #183

---
*PR created automatically by Jules for task [7308440828455550538](https://jules.google.com/task/7308440828455550538) started by @chatelao*